### PR TITLE
Make codebase SQLite compatible

### DIFF
--- a/db/migrate/20251229100653_create_ses_webhook_notifications.rb
+++ b/db/migrate/20251229100653_create_ses_webhook_notifications.rb
@@ -4,7 +4,7 @@ class CreateSesWebhookNotifications < ActiveRecord::Migration[8.1]
       t.string :sns_message_id, null: false
       t.string :sns_type, null: false
       t.datetime :sns_timestamp, null: false
-      t.jsonb :raw_payload, null: false, default: {}
+      t.json :raw_payload, null: false, default: {}
       t.datetime :processed_at
 
       t.timestamps

--- a/db/migrate/20251229100702_create_ses_messages.rb
+++ b/db/migrate/20251229100702_create_ses_messages.rb
@@ -5,7 +5,7 @@ class CreateSesMessages < ActiveRecord::Migration[8.1]
       t.string :source_email
       t.string :subject
       t.datetime :sent_at
-      t.jsonb :mail_metadata, default: {}
+      t.json :mail_metadata, default: {}
       t.integer :events_count, default: 0, null: false
 
       t.timestamps

--- a/db/migrate/20251229100703_create_ses_events.rb
+++ b/db/migrate/20251229100703_create_ses_events.rb
@@ -1,16 +1,14 @@
 class CreateSesEvents < ActiveRecord::Migration[8.1]
   def change
-    create_enum :ses_event_type, %w[Send Delivery Bounce Complaint Reject DeliveryDelay RenderingFailure Subscription Open Click]
-
     create_table :ses_events do |t|
       t.references :message, null: false, foreign_key: { to_table: :ses_messages }
       t.references :webhook_notification, foreign_key: { to_table: :ses_webhook_notifications }
-      t.enum :event_type, enum_type: :ses_event_type, null: false
+      t.string :event_type, null: false
       t.string :recipient_email, null: false
       t.datetime :event_at, null: false
       t.string :ses_message_id, null: false
-      t.jsonb :event_data, default: {}
-      t.jsonb :raw_payload, default: {}
+      t.json :event_data, default: {}
+      t.json :raw_payload, default: {}
       t.string :bounce_type
 
       t.timestamps

--- a/db/migrate/20251229123659_create_sources.rb
+++ b/db/migrate/20251229123659_create_sources.rb
@@ -2,7 +2,7 @@ class CreateSources < ActiveRecord::Migration[8.1]
   def change
     create_table :sources do |t|
       t.string :name, null: false
-      t.uuid :token, null: false, default: "gen_random_uuid()"
+      t.string :token, null: false
 
       t.timestamps
     end

--- a/db/migrate/20251231121604_convert_postgres_types_for_sqlite_compatibility.rb
+++ b/db/migrate/20251231121604_convert_postgres_types_for_sqlite_compatibility.rb
@@ -1,0 +1,81 @@
+class ConvertPostgresTypesForSqliteCompatibility < ActiveRecord::Migration[8.1]
+  def up
+    convert_jsonb_to_json
+    convert_enum_to_string
+    convert_uuid_to_string
+  end
+
+  def down
+    revert_json_to_jsonb
+    revert_string_to_enum
+    revert_string_to_uuid
+  end
+
+  private
+
+  def convert_jsonb_to_json
+    return unless column_type(:events, :event_data) == :jsonb
+
+    change_column :webhooks, :raw_payload, :json, null: false, default: {}
+    change_column :messages, :mail_metadata, :json, default: {}
+    change_column :events, :event_data, :json, default: {}
+    change_column :events, :raw_payload, :json, default: {}
+  end
+
+  def convert_enum_to_string
+    return unless enum_type_exists?(:event_type)
+
+    change_column :events, :event_type, :string, null: false
+    execute "DROP TYPE IF EXISTS event_type"
+  end
+
+  def convert_uuid_to_string
+    return unless column_type(:sources, :token) == :uuid
+
+    change_column :sources, :token, :string, null: false, default: nil
+  end
+
+  def revert_json_to_jsonb
+    return unless column_type(:events, :event_data) == :json && postgresql?
+
+    change_column :webhooks, :raw_payload, :jsonb, null: false, default: {}
+    change_column :messages, :mail_metadata, :jsonb, default: {}
+    change_column :events, :event_data, :jsonb, default: {}
+    change_column :events, :raw_payload, :jsonb, default: {}
+  end
+
+  def revert_string_to_enum
+    return unless postgresql? && !enum_type_exists?(:event_type)
+
+    execute <<-SQL
+      CREATE TYPE event_type AS ENUM (
+        'Send', 'Delivery', 'Bounce', 'Complaint', 'Reject',
+        'DeliveryDelay', 'RenderingFailure', 'Subscription', 'Open', 'Click'
+      )
+    SQL
+    execute "ALTER TABLE events ALTER COLUMN event_type TYPE event_type USING event_type::event_type"
+  end
+
+  def revert_string_to_uuid
+    return unless column_type(:sources, :token) == :string && postgresql?
+
+    execute "ALTER TABLE sources ALTER COLUMN token TYPE uuid USING token::uuid"
+    execute "ALTER TABLE sources ALTER COLUMN token SET DEFAULT gen_random_uuid()"
+    execute "ALTER TABLE sources ALTER COLUMN token SET NOT NULL"
+  end
+
+  def column_type(table, column)
+    connection.columns(table).find { |c| c.name == column.to_s }&.type
+  end
+
+  def enum_type_exists?(name)
+    return false unless postgresql?
+
+    query = "SELECT 1 FROM pg_type WHERE typname = '#{name}'"
+    connection.select_value(query).present?
+  end
+
+  def postgresql?
+    connection.adapter_name.downcase.include?("postgresql")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_30_112213) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_31_121604) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
-
-  # Custom types defined in this database.
-  # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "event_type", ["Send", "Delivery", "Bounce", "Complaint", "Reject", "DeliveryDelay", "RenderingFailure", "Subscription", "Open", "Click"]
 
   create_table "events", force: :cascade do |t|
     t.string "bounce_type"
     t.datetime "created_at", null: false
     t.datetime "event_at", null: false
-    t.jsonb "event_data", default: {}
-    t.enum "event_type", null: false, enum_type: "event_type"
+    t.json "event_data", default: {}
+    t.string "event_type", null: false
     t.bigint "message_id", null: false
-    t.jsonb "raw_payload", default: {}
+    t.json "raw_payload", default: {}
     t.string "recipient_email", null: false
     t.string "ses_message_id", null: false
     t.datetime "updated_at", null: false
@@ -42,7 +38,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_30_112213) do
   create_table "messages", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "events_count", default: 0, null: false
-    t.jsonb "mail_metadata", default: {}
+    t.json "mail_metadata", default: {}
     t.datetime "sent_at"
     t.string "ses_message_id", null: false
     t.string "source_email"
@@ -59,7 +55,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_30_112213) do
     t.string "color", default: "blue"
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.uuid "token", default: -> { "gen_random_uuid()" }, null: false
+    t.string "token", null: false
     t.datetime "updated_at", null: false
     t.index ["token"], name: "index_sources_on_token", unique: true
   end
@@ -67,7 +63,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_30_112213) do
   create_table "webhooks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "processed_at"
-    t.jsonb "raw_payload", default: {}, null: false
+    t.json "raw_payload", default: {}, null: false
     t.string "sns_message_id", null: false
     t.datetime "sns_timestamp", null: false
     t.string "sns_type", null: false


### PR DESCRIPTION
## Summary
- Replace `jsonb` with `json` in migrations (works on both PostgreSQL and SQLite)
- Replace PostgreSQL enum with string column (Rails enum handles validation in model)
- Replace `uuid` with `gen_random_uuid()` default with string (model generates UUID)
- Add conversion migration for existing PostgreSQL deployments (checks column types first, safe for fresh installs)

## Test plan
- [x] Ran migrations on existing PostgreSQL database
- [x] Deployed to production via Kamal
- [x] Test fresh SQLite install (swap pg gem for sqlite3, update database.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)