### PR TITLE
Add configurable data retention per source

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -45,6 +45,6 @@ class SourcesController < ApplicationController
   end
 
   def source_params
-    params.require(:source).permit(:name, :color)
+    params.require(:source).permit(:name, :color, :retention_days)
   end
 end

--- a/app/jobs/delete_expired_data_job.rb
+++ b/app/jobs/delete_expired_data_job.rb
@@ -1,0 +1,9 @@
+class DeleteExpiredDataJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Source.with_retention_policy.find_each do |source|
+      source.delete_expired_data
+    end
+  end
+end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,5 +1,6 @@
 class Source < ApplicationRecord
   include Colors
+  include RetentionPolicy
 
   has_many :messages, dependent: :destroy
   has_many :events, through: :messages

--- a/app/models/source/retention_policy.rb
+++ b/app/models/source/retention_policy.rb
@@ -1,0 +1,19 @@
+module Source::RetentionPolicy
+  extend ActiveSupport::Concern
+
+  included do
+    validates :retention_days, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
+
+    scope :with_retention_policy, -> { where.not(retention_days: nil) }
+  end
+
+  def delete_expired_data
+    return 0 unless retention_days
+
+    expired_messages = messages.where(sent_at: ..retention_days.days.ago)
+    return 0 unless expired_messages.exists?
+
+    Event.where(message_id: expired_messages.select(:id)).delete_all
+    expired_messages.delete_all
+  end
+end

--- a/app/views/sources/edit.html.erb
+++ b/app/views/sources/edit.html.erb
@@ -20,6 +20,15 @@
         <%= render "color_picker", f: f %>
       </div>
 
+      <div class="mb-4">
+        <%= f.label :retention_days, "Data Retention", class: "block text-sm font-medium mb-1" %>
+        <div class="flex items-center gap-2">
+          <%= f.number_field :retention_days, min: 1, placeholder: "Days", class: "block w-24 border rounded px-3 py-2 text-sm" %>
+          <span class="text-sm text-gray-500">days</span>
+        </div>
+        <p class="text-xs text-gray-400 mt-1">Leave empty to keep messages forever</p>
+      </div>
+
       <div class="flex justify-between items-center">
         <%= f.submit "Save Changes", class: "px-3 py-1.5 text-sm border rounded hover:bg-gray-50 cursor-pointer" %>
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,7 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+
+  delete_expired_data:
+    class: DeleteExpiredDataJob
+    schedule: every day at 4am

--- a/db/migrate/20260101090207_add_retention_days_to_sources.rb
+++ b/db/migrate/20260101090207_add_retention_days_to_sources.rb
@@ -1,0 +1,5 @@
+class AddRetentionDaysToSources < ActiveRecord::Migration[8.1]
+  def change
+    add_column :sources, :retention_days, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_31_121604) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_01_090207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_31_121604) do
     t.string "color", default: "blue"
     t.datetime "created_at", null: false
     t.string "name", null: false
+    t.integer "retention_days"
     t.string "token", null: false
     t.datetime "updated_at", null: false
     t.index ["token"], name: "index_sources_on_token", unique: true

--- a/test/models/source_retention_policy_test.rb
+++ b/test/models/source_retention_policy_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+class Source::RetentionPolicyTest < ActiveSupport::TestCase
+  setup do
+    @source = Source.create!(name: "Test Source", retention_days: 30)
+  end
+
+  # Validation tests
+
+  test "retention_days can be nil" do
+    source = Source.new(name: "Test", retention_days: nil)
+    assert source.valid?
+  end
+
+  test "retention_days must be positive" do
+    source = Source.new(name: "Test", retention_days: 0)
+    assert_not source.valid?
+    assert_includes source.errors[:retention_days], "must be greater than 0"
+  end
+
+  test "retention_days rejects negative values" do
+    source = Source.new(name: "Test", retention_days: -5)
+    assert_not source.valid?
+  end
+
+  test "retention_days must be an integer" do
+    source = Source.new(name: "Test", retention_days: 30.5)
+    assert_not source.valid?
+    assert_includes source.errors[:retention_days], "must be an integer"
+  end
+
+  # Scope tests
+
+  test "with_retention_policy includes sources with retention_days set" do
+    source_with_policy = Source.create!(name: "With Policy", retention_days: 30)
+    source_without_policy = Source.create!(name: "Without Policy", retention_days: nil)
+
+    results = Source.with_retention_policy
+
+    assert_includes results, source_with_policy
+    assert_not_includes results, source_without_policy
+  end
+
+  # delete_expired_data tests
+
+  test "delete_expired_data returns 0 when retention_days is nil" do
+    source = Source.create!(name: "No Retention", retention_days: nil)
+    assert_equal 0, source.delete_expired_data
+  end
+
+  test "delete_expired_data returns 0 when no messages exist" do
+    assert_equal 0, @source.delete_expired_data
+  end
+
+  test "delete_expired_data returns 0 when no expired messages exist" do
+    create_message(@source, sent_at: 5.days.ago)
+
+    assert_equal 0, @source.delete_expired_data
+  end
+
+  test "delete_expired_data deletes expired messages" do
+    expired_message = create_message(@source, sent_at: 60.days.ago)
+    recent_message = create_message(@source, sent_at: 5.days.ago)
+
+    deleted_count = @source.delete_expired_data
+
+    assert_equal 1, deleted_count
+    assert_not Message.exists?(expired_message.id)
+    assert Message.exists?(recent_message.id)
+  end
+
+  test "delete_expired_data deletes events for expired messages" do
+    expired_message = create_message(@source, sent_at: 60.days.ago)
+    expired_event = create_event(expired_message)
+
+    recent_message = create_message(@source, sent_at: 5.days.ago)
+    recent_event = create_event(recent_message)
+
+    @source.delete_expired_data
+
+    assert_not Event.exists?(expired_event.id)
+    assert Event.exists?(recent_event.id)
+  end
+
+  test "delete_expired_data respects retention_days setting" do
+    @source.update!(retention_days: 7)
+
+    message_8_days_old = create_message(@source, sent_at: 8.days.ago)
+    message_6_days_old = create_message(@source, sent_at: 6.days.ago)
+
+    @source.delete_expired_data
+
+    assert_not Message.exists?(message_8_days_old.id)
+    assert Message.exists?(message_6_days_old.id)
+  end
+
+  private
+
+  def create_message(source, sent_at:)
+    Message.create!(
+      source: source,
+      ses_message_id: SecureRandom.uuid,
+      sent_at: sent_at
+    )
+  end
+
+  def create_event(message)
+    Event.create!(
+      message: message,
+      ses_message_id: message.ses_message_id,
+      event_type: "send",
+      event_at: message.sent_at,
+      recipient_email: "test@example.com"
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- Add `retention_days` column to sources (NULL = keep forever)
- `DeleteExpiredDataJob` runs daily at 4am to delete expired messages and events
- UI field in source settings to configure retention period

Closes #6

<img width="846" height="598" alt="CleanShot 2026-01-01 at 16 39 41@2x" src="https://github.com/user-attachments/assets/af5253cf-4bca-4b4f-a17c-0bfc91bcedf2" />

## Test plan
- [x] Set retention_days on a source and verify old messages are deleted
- [x] Verify sources without retention_days keep data forever
- [x] Run `DeleteExpiredDataJob.perform_now` manually to test

🤖 Generated with [Claude Code](https://claude.ai/code)