### PR TITLE
Automate Docker image build + push across linux/amd64, linux/arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,12 @@
 name: CI
 
-permissions:
-  contents: read
-  packages: write
-
 on:
   pull_request:
   push:
     branches: [ main ]
 
 jobs:
-  scan-ruby:
+  scan_ruby:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +24,7 @@ jobs:
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
       
-  scan-js:
+  scan_js:
     runs-on: ubuntu-latest
 
     steps:
@@ -154,75 +150,3 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
-    
-  docker-push-amd64:
-    runs-on: ubuntu-latest
-    needs: [lint, scan-ruby, scan-js, test, system-test]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-    
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-    
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-    
-      - name: Extract metadata (tags)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
-    
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-          
-  docker-push-arm64:
-    runs-on: ubuntu-24.04-arm
-    needs: [lint, scan-ruby, scan-js, test, system-test]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-    
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-    
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-    
-      - name: Extract metadata (tags)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
-    
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm64

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,199 @@
+name: Build and publish container image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  IMAGE_DESCRIPTION: Open-source email observability for AWS SES.
+  SOURCE_URL: https://github.com/${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and push image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            arch: arm64
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute canonical image name (lowercase)
+        id: vars
+        shell: bash
+        run: |
+          set -eu
+          IMAGE_REF="${IMAGE_NAME:-$GITHUB_REPOSITORY}"
+          CANONICAL_IMAGE="${REGISTRY}/${IMAGE_REF,,}"
+          echo "canonical=${CANONICAL_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata (tags, labels) with arch suffix
+        id: meta
+        uses: docker/metadata-action@v5.10.0
+        with:
+          images: ${{ steps.vars.outputs.canonical }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short,prefix=sha-
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          flavor: |
+            latest=false
+            suffix=-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=${{ env.SOURCE_URL }}
+
+      - name: Build and push (${{ matrix.platform }})
+        id: build
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: Dockerfile
+          build-args: |
+            OCI_SOURCE=${{ env.SOURCE_URL }}
+            OCI_DESCRIPTION=${{ env.IMAGE_DESCRIPTION }}
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          sbom: false
+          provenance: false
+
+      - name: Attest image provenance (per-arch)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v3.1.0
+        with:
+          subject-name: ${{ steps.vars.outputs.canonical }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: false
+
+  manifest:
+    name: Create multi-arch manifest and sign
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Set up Docker Buildx (for imagetools)
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute canonical image name (lowercase)
+        id: vars
+        shell: bash
+        run: |
+          set -eu
+          IMAGE_REF="${IMAGE_NAME:-$GITHUB_REPOSITORY}"
+          CANONICAL_IMAGE="${REGISTRY}/${IMAGE_REF,,}"
+          echo "canonical=${CANONICAL_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute base tags (no suffix)
+        id: meta
+        uses: docker/metadata-action@v5.10.0
+        with:
+          images: ${{ steps.vars.outputs.canonical }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short,prefix=sha-
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          flavor: |
+            latest=false
+          labels: |
+            org.opencontainers.image.source=${{ env.SOURCE_URL }}
+
+      - name: Create multi-arch manifests
+        shell: bash
+        run: |
+          set -eu
+          tags="${{ steps.meta.outputs.tags }}"
+          echo "Creating manifests for tags:"
+          printf '%s\n' "$tags"
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Creating manifest for $tag"
+            src_tag="$tag"
+            if [[ "$tag" == *:latest && "${GITHUB_REF}" == refs/tags/* ]]; then
+              ref="${GITHUB_REF#refs/tags/}"
+              src_tag="${tag%:latest}:$ref"
+            fi
+            if [ -n "${IMAGE_DESCRIPTION:-}" ]; then
+              docker buildx imagetools create \
+                --tag "$tag" \
+                --annotation "index:org.opencontainers.image.description=${IMAGE_DESCRIPTION}" \
+                "${src_tag}-amd64" \
+                "${src_tag}-arm64"
+            else
+              docker buildx imagetools create \
+                --tag "$tag" \
+                "${src_tag}-amd64" \
+                "${src_tag}-arm64"
+            fi
+          done <<< "$tags"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
+      - name: Cosign sign all tags (keyless OIDC)
+        shell: bash
+        run: |
+          set -eu
+          tags="${{ steps.meta.outputs.tags }}"
+          printf '%s\n' "$tags"
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Signing $tag"
+            cosign sign --yes "$tag"
+          done <<< "$tags"


### PR DESCRIPTION
Updated the CI script:
1. Added cross platform Docker build + push with default GitHub credentials (OSS repos get free docker image hosting, I'm using the builtin credentials for this)
2. Fixed casing in job names to be consistent with the usual YAML conventions (kebab-case)

This should make it easier for people to try out Sessy regardless of what type of deployment tool they use, and should make running it locally easier too