### PR TITLE
Add security warning banner when HTTP auth is not configured

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,8 @@
 module ApplicationHelper
+  def show_auth_warning?
+    !Rails.env.local? &&
+      ENV["HTTP_AUTH_USERNAME"].blank? &&
+      ENV["HTTP_AUTH_PASSWORD"].blank? &&
+      ENV["DISABLE_AUTH_WARNING"].blank?
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,14 @@
   <body>
     <%= render "layouts/header" %>
 
+    <% if show_auth_warning? %>
+      <div class="bg-amber-500 text-amber-950 px-4 py-3 text-center text-sm">
+        <strong>Security Warning:</strong> This instance has no authentication configured. Anyone with the URL can access it.
+        Set <code class="bg-amber-600/30 px-1 rounded">HTTP_AUTH_USERNAME</code> and <code class="bg-amber-600/30 px-1 rounded">HTTP_AUTH_PASSWORD</code> to enable HTTP Basic Auth,
+        or <code class="bg-amber-600/30 px-1 rounded">DISABLE_AUTH_WARNING</code> to hide this warning.
+      </div>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -74,6 +74,12 @@ docker run \
 
 When both variables are set, Sessy will require authentication to access the dashboard. Webhook endpoints remain accessible without authentication so AWS SES can deliver events.
 
+If HTTP Basic Auth is not configured, Sessy will display a security warning banner. To disable this warning (for example, if you're using a different authentication method), set:
+
+```sh
+docker run --environment DISABLE_AUTH_WARNING=true ...
+```
+
 #### Database
 
 By default, Sessy uses SQLite and stores its database in the mounted storage volume. This is the simplest setup and works great for most use cases.

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class ApplicationHelperTest < ActionView::TestCase
+  test "show_auth_warning? returns false in local environment" do
+    assert_not show_auth_warning?
+  end
+
+  test "show_auth_warning? returns false when HTTP auth is configured" do
+    with_env("HTTP_AUTH_USERNAME" => "user", "HTTP_AUTH_PASSWORD" => "pass") do
+      assert_not show_auth_warning?
+    end
+  end
+
+  test "show_auth_warning? returns false when warning is disabled" do
+    with_env("DISABLE_AUTH_WARNING" => "1") do
+      assert_not show_auth_warning?
+    end
+  end
+
+  private
+
+  def with_env(vars)
+    old_values = vars.keys.to_h { |k| [ k, ENV[k] ] }
+    vars.each { |k, v| ENV[k] = v }
+    yield
+  ensure
+    old_values.each { |k, v| ENV[k] = v }
+  end
+end


### PR DESCRIPTION
## Summary
- Shows an amber warning banner in production when `HTTP_AUTH_USERNAME` and `HTTP_AUTH_PASSWORD` are not set
- Warning can be suppressed with `DISABLE_AUTH_WARNING` env var
- Only shows in non-local environments (production/staging)

## Test plan
- [ ] Deploy to production without HTTP auth configured → warning should appear
- [ ] Set `HTTP_AUTH_USERNAME` and `HTTP_AUTH_PASSWORD` → warning should disappear
- [ ] Set `DISABLE_AUTH_WARNING=1` → warning should disappear
- [ ] Run locally in development → warning should not appear