### PR TITLE
Fix foreman path to prevent dev setup failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ end
 
 group :development do
   gem "web-console"
+  gem "foreman", "~> 0.90.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    foreman (0.90.0)
+      thor (~> 1.4)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -414,6 +416,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
+  foreman (~> 0.90.0)
   importmap-rails
   kamal
   minitest (~> 5.0)
@@ -476,6 +479,7 @@ CHECKSUMS
   erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
+  foreman (0.90.0) sha256=ff675e2d47b607ac58714a6d4ac3e1ee8f06f41d8db084531c31961e2c3f117c
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5

--- a/bin/dev
+++ b/bin/dev
@@ -1,10 +1,5 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
@@ -13,4 +8,4 @@ export PORT="${PORT:-3000}"
 export RUBY_DEBUG_OPEN="true"
 export RUBY_DEBUG_LAZY="true"
 
-exec foreman start -f Procfile.dev "$@"
+bundle exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
foreman was installed at some random directory when I ran bin/setup, so it failed to find the executable and setup failed as a result.

This is common in my experience when there are multiple versions of Ruby installed etc, so to make this more reliable I simply added it as a part of the bundle under the dev group and used `bundle exec` as a prefix to force it to find the foreman installed as a dependency of the project instead of some global foreman binary.

This resolved the issue for me. I'm not a ruby dev so I'm not sure if this is the best way to go about it, let me know if I'm missing anything.