### PR TITLE
Add demo seed data for development testing

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@ puts "Created source: #{source.name} (token: #{source.token})"
 source_email = "hello@example.com"
 
 base_time = Time.zone.local(2026, 1, 1, 9, 0, 0)
-event_offsets = [45, 120, 300, 540, 900]
+event_offsets = [ 45, 120, 300, 540, 900 ]
 
 # Create messages with events at various times
 messages = [
@@ -76,7 +76,7 @@ messages.each do |message_seed|
       subject: message_seed[:subject],
       sent_at:,
       mail_metadata: {
-        "destination" => [message_seed[:recipient]],
+        "destination" => [ message_seed[:recipient] ],
         "tags" => { "environment" => "demo", "campaign" => "seed-data" }
       }
     )


### PR DESCRIPTION
Creates a Demo App source with 7 sample messages and 22 events spanning various timestamps (5 minutes to 2 weeks ago) and event types (send, delivery, open, click, bounce, complaint).

<img width="2036" height="1444" alt="CleanShot 2026-01-06 at 22 38 22@2x" src="https://github.com/user-attachments/assets/8303b250-67d0-4f77-bc3e-a2fc7e135e8d" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)