### PR TITLE
Support sub-path mounting via Rack::URLMap

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,23 @@
 
 require_relative "config/environment"
 
-run Rails.application
+# Mount the Rails app under RAILS_RELATIVE_URL_ROOT via Rack::URLMap when
+# Sessy is being served from a sub-path (e.g. behind a reverse proxy at
+# /sessy or /admin/sessy). URLMap strips the prefix from PATH_INFO so the
+# Rails router matches the canonical routes, and sets SCRIPT_NAME on the
+# inner request so URL helpers in views, forms, redirects, and the asset
+# pipeline emit correctly-prefixed URLs (including the webhook URL shown
+# on the source setup page).
+#
+# Without this, RAILS_RELATIVE_URL_ROOT only affects URL generation
+# OUTSIDE a request context (mailers, jobs). In-request URL helpers see
+# request.script_name == "" and emit unprefixed paths, breaking every
+# link Sessy renders when mounted at a sub-path.
+relative_root = ENV["RAILS_RELATIVE_URL_ROOT"].to_s
+if !relative_root.empty? && relative_root != "/"
+  map(relative_root) { run Rails.application }
+else
+  run Rails.application
+end
+
 Rails.application.load_server

--- a/config.ru
+++ b/config.ru
@@ -2,18 +2,8 @@
 
 require_relative "config/environment"
 
-# Mount the Rails app under RAILS_RELATIVE_URL_ROOT via Rack::URLMap when
-# Sessy is being served from a sub-path (e.g. behind a reverse proxy at
-# /sessy or /admin/sessy). URLMap strips the prefix from PATH_INFO so the
-# Rails router matches the canonical routes, and sets SCRIPT_NAME on the
-# inner request so URL helpers in views, forms, redirects, and the asset
-# pipeline emit correctly-prefixed URLs (including the webhook URL shown
-# on the source setup page).
-#
-# Without this, RAILS_RELATIVE_URL_ROOT only affects URL generation
-# OUTSIDE a request context (mailers, jobs). In-request URL helpers see
-# request.script_name == "" and emit unprefixed paths, breaking every
-# link Sessy renders when mounted at a sub-path.
+# Sub-path deploys (e.g. reverse proxy at /sessy): Rack::URLMap strips the prefix
+# from PATH_INFO for routing and sets SCRIPT_NAME so URL helpers include the mount.
 relative_root = ENV["RAILS_RELATIVE_URL_ROOT"].to_s
 if !relative_root.empty? && relative_root != "/"
   map(relative_root) { run Rails.application }


### PR DESCRIPTION
## Summary

When `RAILS_RELATIVE_URL_ROOT` is set, mount the Rails application under `Rack::URLMap` in `config.ru` so the prefix is stripped from `PATH_INFO` and `SCRIPT_NAME` is set on the inner request. This makes Rails URL helpers (`link_to`, `form_with`, `redirect_to`, `asset_path`, `webhook_url`, etc.) emit correctly-prefixed URLs in views.

Behavior is unchanged when `RAILS_RELATIVE_URL_ROOT` is unset or `/`.

## Why

Without this, `RAILS_RELATIVE_URL_ROOT` only affects URL generation **outside** a request context (mailers, jobs). In-request URL helpers go through `ActionController::UrlFor#url_options`, which sets `options[:script_name] = request.script_name` ([actionpack/lib/action_controller/metal/url_for.rb#L54](https://github.com/rails/rails/blob/8-1-stable/actionpack/lib/action_controller/metal/url_for.rb#L54)) — and when no URLMap is in front, that's an empty string. `find_script_name` then short-circuits in `||` because `""` is truthy in Ruby ([actionpack/lib/action_dispatch/routing/route_set.rb#L847](https://github.com/rails/rails/blob/8-1-stable/actionpack/lib/action_dispatch/routing/route_set.rb#L847)) and never falls back to `relative_url_root`.

In practice, this means every link, form, redirect, and the webhook URL displayed on the source setup page (`app/views/setups/show.html.erb:38`) loses its prefix and 404s on the next click when Sessy is proxied at a sub-path.

## Repro (without this PR)

Run Sessy with a relative URL root, simulating a reverse proxy that forwards the prefix:

```
docker run --rm -p 80:80 \
  -e SECRET_KEY_BASE=$(openssl rand -hex 64) \
  -e DISABLE_SSL=true \
  -e RAILS_RELATIVE_URL_ROOT=/sessy \
  ghcr.io/marckohlbrugge/sessy:main
```

Then `curl -i http://localhost/sessy/` returns 404 because Rails routes don't match the prefixed `PATH_INFO`. With this PR, `Rack::URLMap` strips the prefix and the request matches the `root` route as expected.

## Test plan

- [x] `RAILS_RELATIVE_URL_ROOT` unset → falls through to `run Rails.application` (unchanged behavior)
- [x] `RAILS_RELATIVE_URL_ROOT="/"` → falls through to `run Rails.application` (unchanged behavior)
- [x] `RAILS_RELATIVE_URL_ROOT="/sessy"` → URLMap mounts at `/sessy`, requests at `/sessy/...` route correctly, URL helpers emit `/sessy/...`

## Notes

This is the standard Rails sub-path mounting idiom (the `map` block in `config.ru`); Sessy was just missing it. After this lands, deploying Sessy behind a sub-path reverse proxy works end-to-end with no other config changes.
