### PR TITLE
Keep focus on search field while typing

### DIFF
--- a/app/javascript/controllers/debounced_submit_controller.js
+++ b/app/javascript/controllers/debounced_submit_controller.js
@@ -1,6 +1,15 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = [ "input" ]
+
+  // Permanent inputs survive Turbo renders, so sync them with the URL unless the user is typing
+  inputTargetConnected(input) {
+    if (document.activeElement !== input) {
+      input.value = new URLSearchParams(location.search).get(input.name) || ""
+    }
+  }
+
   submit() {
     if (this.timer) clearTimeout(this.timer)
     this.timer = setTimeout(() => this.element.requestSubmit(), 300)

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,7 +6,7 @@
             placeholder: "Search by email or subject...",
             class: "w-full max-w-sm border border-zinc-950/10 dark:border-white/10 bg-transparent px-2.5 py-1.5 text-sm placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-950/20 dark:focus:ring-white/20",
             "aria-label": "Search events",
-            data: { action: "input->debounced-submit#submit search->debounced-submit#submit" } %>
+            data: { turbo_permanent: true, debounced_submit_target: "input", action: "input->debounced-submit#submit search->debounced-submit#submit" } %>
 
         <div class="flex items-center gap-2 ml-auto">
           <%= link_to "Export", source_events_path(@source, format: :csv, **request.query_parameters), class: "px-2.5 py-1.5 text-sm border border-zinc-950/10 dark:border-white/10 hover:bg-zinc-50 dark:hover:bg-white/5 whitespace-nowrap" %>

--- a/test/system/event_search_test.rb
+++ b/test/system/event_search_test.rb
@@ -1,0 +1,26 @@
+require "application_system_test_case"
+
+class EventSearchTest < ApplicationSystemTestCase
+  test "search field keeps focus while results update" do
+    visit source_events_path(sources(:betalist))
+
+    fill_in "query", with: "marc"
+
+    assert_no_text "john@example.com"
+    assert_text "marc@example.com"
+
+    assert_equal "query", page.evaluate_script("document.activeElement.id")
+  end
+
+  test "search field resets when navigating to an unfiltered page" do
+    visit source_events_path(sources(:betalist))
+
+    fill_in "query", with: "marc"
+    assert_no_text "john@example.com"
+
+    click_link "Activity"
+    assert_text "john@example.com"
+
+    assert_equal "", find_field("query").value
+  end
+end


### PR DESCRIPTION
Fixes #143

The search field auto-submits 300ms after you stop typing. That's a full Turbo Drive visit, so the input element was destroyed on every render and focus was lost mid-typing.

- Mark the search input `data-turbo-permanent`: Turbo 8 carries the same DOM node across renders and restores focus to it, preserving caret position and any text typed while a request was in flight.
- A permanent input would keep stale text when navigating somewhere the query doesn't apply (e.g. clicking the Activity tab), so the debounced-submit controller now syncs the input from the URL when it connects, unless it's focused. This uses `inputTargetConnected` rather than `connect` because Turbo inserts permanent elements after the body swap, past the point where `connect` fires.

System tests cover both behaviors; the focus test fails without the fix.