### PR TITLE
Add SaaS engine foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,16 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager
+        run: bin/brakeman --no-pager --add-engines-path saas
 
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
+
+      - name: Scan the SaaS lockfile for known security vulnerabilities
+        run: bin/bundler-audit check --gemfile-lock Gemfile.saas.lock
+
+      - name: Check Gemfile.saas.lock is in sync with Gemfile.lock
+        run: bin/bundle-drift --check
 
   scan_js:
     runs-on: ubuntu-latest
@@ -66,17 +72,21 @@ jobs:
         run: bin/rubocop -f github
 
   test:
-    name: test (${{ matrix.database }})
+    name: test (${{ matrix.label }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - database: SQLite
+          - label: SQLite
             database_adapter: sqlite
-          - database: PostgreSQL
+          - label: PostgreSQL
             database_adapter: postgresql
+          - label: PostgreSQL SaaS
+            database_adapter: postgresql
+            bundle_gemfile: Gemfile.saas
+            sessy_mode: saas
 
     services:
       postgres:
@@ -91,6 +101,8 @@ jobs:
     env:
       RAILS_ENV: test
       DATABASE_ADAPTER: ${{ matrix.database_adapter }}
+      BUNDLE_GEMFILE: ${{ matrix.bundle_gemfile || 'Gemfile' }}
+      SESSY_MODE: ${{ matrix.sessy_mode || '' }}
       POSTGRES_HOST: localhost
       POSTGRES_PORT: 5432
       POSTGRES_USER: postgres
@@ -111,6 +123,10 @@ jobs:
       - name: Run tests
         run: bin/rails db:test:prepare test
 
+      - name: Run engine tests
+        if: matrix.sessy_mode == 'saas'
+        run: bin/rails test saas/test
+
       - name: Run system tests
         run: bin/rails test:system
 
@@ -118,6 +134,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: screenshots-${{ matrix.database }}
+          name: screenshots-${{ matrix.label }}
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore

--- a/.github/workflows/sync-saas-lockfile.yml
+++ b/.github/workflows/sync-saas-lockfile.yml
@@ -1,0 +1,46 @@
+# Dependabot only updates Gemfile.lock; this carries the changes over to
+# Gemfile.saas.lock so the SaaS CI leg's frozen install keeps passing.
+#
+# The push authenticates with SAAS_LOCKFILE_SYNC_TOKEN, a fine-grained PAT
+# with contents:write on this repo, stored as both an Actions secret and a
+# Dependabot secret. The default GITHUB_TOKEN cannot be used: commits it
+# pushes trigger no workflow runs (required checks would hang forever), and
+# dependabot-triggered runs get a read-only default token anyway.
+name: Sync SaaS lockfile
+
+on:
+  pull_request:
+    paths: [ "Gemfile", "Gemfile.lock" ]
+
+# The default GITHUB_TOKEN needs no write scope: the push authenticates with
+# the PAT via the checkout token input.
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.SAAS_LOCKFILE_SYNC_TOKEN }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+
+      - name: Sync Gemfile.saas.lock
+        run: bin/bundle-drift
+
+      - name: Commit and push if changed
+        run: |
+          if ! git diff --quiet Gemfile.saas.lock; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add Gemfile.saas.lock
+            git commit -m "Sync Gemfile.saas.lock with Gemfile.lock"
+            git push
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,23 @@ Uses Solid Queue. Recurring jobs defined in `config/recurring.yml`:
 
 Uses Minitest. Tests run in parallel. Fixtures in `test/fixtures/`.
 
-CI runs tests against both SQLite and PostgreSQL via matrix strategy.
+CI runs tests against both SQLite and PostgreSQL via matrix strategy, plus one SaaS-mode leg (PostgreSQL).
+
+## SaaS Mode
+
+The `saas/` directory holds `sessy-saas`, a companion Rails engine for the hosted version of Sessy. It is loaded only when bundling with `Gemfile.saas`; the default `Gemfile` ignores it entirely, so open-source installs carry no hosted-only code. `Sessy.saas?` reports at runtime whether the engine is loaded.
+
+`SESSY_MODE=saas` selects `Gemfile.saas` in the pre-boot entry points (`config/boot.rb`, `bin/setup`, `bin/ci`):
+
+```bash
+SESSY_MODE=saas bin/setup            # set up with the SaaS bundle
+SESSY_MODE=saas bin/rails test test saas/test  # core + engine suites in SaaS mode
+SESSY_MODE=saas bin/ci               # full local pipeline in SaaS mode
+```
+
+`Gemfile.saas.lock` must stay in sync with `Gemfile.lock`; run `bin/bundle-drift` to check and repair after changing the Gemfile.
+
+Contributor policy: if the SaaS CI leg fails on an external contribution, fixing it is the maintainer's responsibility, not the contributor's.
 
 ## Event Types
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,13 @@ RUN apt-get update -qq && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
+# Build with --build-arg BUNDLE_GEMFILE=Gemfile.saas for the hosted edition;
+# the default produces the pure open-source image.
+ARG BUNDLE_GEMFILE=Gemfile
+
 # Set production environment variables and enable jemalloc for reduced memory usage and latency.
 ENV RAILS_ENV="production" \
+    BUNDLE_GEMFILE=$BUNDLE_GEMFILE \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development" \
@@ -35,8 +40,11 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev pkg-config && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Install application gems
-COPY Gemfile Gemfile.lock vendor ./
+# Install application gems. The sessy-saas path gem must be present before
+# bundle install; a separate COPY keeps the directory (multi-source COPY
+# into ./ would flatten its contents).
+COPY Gemfile Gemfile.lock Gemfile.saas Gemfile.saas.lock vendor ./
+COPY saas saas/
 
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
@@ -45,6 +53,10 @@ RUN bundle install && \
 
 # Copy application code
 COPY . .
+
+# The open-source image ships without the hosted-edition engine; only the
+# Gemfile.saas build keeps it.
+RUN if [ "$BUNDLE_GEMFILE" = "Gemfile" ]; then rm -rf saas Gemfile.saas Gemfile.saas.lock; fi
 
 # Precompile bootsnap code for faster boot times.
 # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     lint_roller (1.1.0)
     local_time (3.0.3)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -278,8 +278,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -509,7 +509,7 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   local_time (3.0.3) sha256=c69a8974d993fdf6e60db02977ed23c070f203dcb3a1ff0de52ad3d2393f8303
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
@@ -557,7 +557,7 @@ CHECKSUMS
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -1,0 +1,3 @@
+eval_gemfile "Gemfile"
+
+gem "sessy-saas", path: "saas"

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -1,0 +1,627 @@
+PATH
+  remote: saas
+  specs:
+    sessy-saas (0.1.0)
+      rails (>= 8.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    action_text-trix (2.1.18)
+      railties
+    actioncable (8.1.3)
+      actionpack (= 8.1.3)
+      activesupport (= 8.1.3)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (8.1.3)
+      actionpack (= 8.1.3)
+      activejob (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
+      mail (>= 2.8.0)
+    actionmailer (8.1.3)
+      actionpack (= 8.1.3)
+      actionview (= 8.1.3)
+      activejob (= 8.1.3)
+      activesupport (= 8.1.3)
+      mail (>= 2.8.0)
+      rails-dom-testing (~> 2.2)
+    actionpack (8.1.3)
+      actionview (= 8.1.3)
+      activesupport (= 8.1.3)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+      useragent (~> 0.16)
+    actiontext (8.1.3)
+      action_text-trix (~> 2.1.15)
+      actionpack (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (8.1.3)
+      activesupport (= 8.1.3)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (8.1.3)
+      activesupport (= 8.1.3)
+      globalid (>= 0.3.6)
+    activemodel (8.1.3)
+      activesupport (= 8.1.3)
+    activerecord (8.1.3)
+      activemodel (= 8.1.3)
+      activesupport (= 8.1.3)
+      timeout (>= 0.4.0)
+    activestorage (8.1.3)
+      actionpack (= 8.1.3)
+      activejob (= 8.1.3)
+      activerecord (= 8.1.3)
+      activesupport (= 8.1.3)
+      marcel (~> 1.0)
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1269.0)
+    aws-sdk-core (3.254.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-rails (5.1.0)
+      aws-sdk-core (~> 3)
+      railties (>= 7.1.0)
+    aws-sdk-sns (1.118.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bcrypt_pbkdf (1.1.2)
+    bigdecimal (4.1.2)
+    bindex (0.8.1)
+    bootsnap (1.24.6)
+      msgpack (~> 1.2)
+    brakeman (8.0.5)
+      racc
+    builder (3.3.0)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    concurrent-ruby (1.3.7)
+    connection_pool (3.0.2)
+    crass (1.0.7)
+    csv (3.3.5)
+    date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    dotenv (3.2.0)
+    drb (2.2.3)
+    ed25519 (1.4.0)
+    erb (6.0.4)
+    erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
+    globalid (1.3.0)
+      activesupport (>= 6.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    importmap-rails (2.2.3)
+      actionpack (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      railties (>= 6.0.0)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jmespath (1.6.2)
+    json (2.21.1)
+    kamal (2.12.0)
+      activesupport (>= 7.0)
+      base64 (~> 0.2)
+      bcrypt_pbkdf (~> 1.0)
+      concurrent-ruby (~> 1.2)
+      dotenv (~> 3.1)
+      ed25519 (~> 1.4)
+      net-ssh (~> 7.3)
+      sshkit (>= 1.23.0, < 2.0)
+      thor (~> 1.3)
+      zeitwerk (>= 2.6.18, < 3.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    local_time (3.0.3)
+    logger (1.7.0)
+    loofah (2.25.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.0)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.1.0)
+    matrix (0.4.3)
+    mini_mime (1.1.5)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
+    msgpack (1.8.3)
+    net-imap (0.6.4.1)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.3)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-musl)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    pagy (43.6.0)
+      json
+      uri
+      yaml
+    parallel (1.27.0)
+    parser (3.3.10.0)
+      ast (~> 2.4.1)
+      racc
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    propshaft (1.3.2)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+    psych (5.4.0)
+      date
+      stringio
+    public_suffix (7.0.5)
+    puma (8.0.2)
+      nio4r (~> 2.0)
+    raabro (1.4.0)
+    racc (1.8.1)
+    rack (3.2.6)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (2.3.1)
+      rack (>= 3)
+    rails (8.1.3)
+      actioncable (= 8.1.3)
+      actionmailbox (= 8.1.3)
+      actionmailer (= 8.1.3)
+      actionpack (= 8.1.3)
+      actiontext (= 8.1.3)
+      actionview (= 8.1.3)
+      activejob (= 8.1.3)
+      activemodel (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
+      bundler (>= 1.15.0)
+      railties (= 8.1.3)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (8.1.3)
+      actionpack (= 8.1.3)
+      activesupport (= 8.1.3)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
+    rainbow (3.1.1)
+    rake (13.4.2)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rubocop (1.82.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rails (2.34.2)
+      activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
+      rack (>= 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-rails-omakase (1.1.0)
+      rubocop (>= 1.72)
+      rubocop-performance (>= 1.24)
+      rubocop-rails (>= 2.30)
+    ruby-progressbar (1.13.0)
+    rubyzip (3.4.1)
+    securerandom (0.4.1)
+    selenium-webdriver (4.46.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 4.0)
+      websocket (~> 1.0)
+    solid_cable (3.0.12)
+      actioncable (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
+    sqlite3 (2.9.5-aarch64-linux-gnu)
+    sqlite3 (2.9.5-aarch64-linux-musl)
+    sqlite3 (2.9.5-arm-linux-gnu)
+    sqlite3 (2.9.5-arm-linux-musl)
+    sqlite3 (2.9.5-arm64-darwin)
+    sqlite3 (2.9.5-x86_64-linux-gnu)
+    sqlite3 (2.9.5-x86_64-linux-musl)
+    sshkit (1.25.0)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    stimulus-rails (1.3.4)
+      railties (>= 6.0.0)
+    stringio (3.2.0)
+    tailwindcss-rails (4.6.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.3.1)
+    tailwindcss-ruby (4.3.1-aarch64-linux-gnu)
+    tailwindcss-ruby (4.3.1-aarch64-linux-musl)
+    tailwindcss-ruby (4.3.1-arm64-darwin)
+    tailwindcss-ruby (4.3.1-x86_64-linux-gnu)
+    tailwindcss-ruby (4.3.1-x86_64-linux-musl)
+    thor (1.5.0)
+    thruster (0.1.22)
+    thruster (0.1.22-aarch64-linux)
+    thruster (0.1.22-arm64-darwin)
+    thruster (0.1.22-x86_64-linux)
+    timeout (0.6.1)
+    tsort (0.2.0)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    useragent (0.16.11)
+    web-console (4.3.0)
+      actionview (>= 8.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 8.0.0)
+    websocket (1.2.11)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+    yaml (0.4.0)
+    zeitwerk (2.8.2)
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin-24
+  arm64-darwin-25
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  aws-sdk-rails
+  aws-sdk-sns
+  bootsnap
+  brakeman
+  bundler-audit
+  capybara
+  csv
+  debug
+  importmap-rails
+  kamal
+  local_time
+  minitest (~> 6.0)
+  mission_control-jobs
+  pagy
+  pg (~> 1.1)
+  propshaft
+  puma (>= 5.0)
+  rails (~> 8.1.3)
+  rubocop-rails-omakase
+  selenium-webdriver
+  sessy-saas!
+  solid_cable
+  solid_cache
+  solid_queue
+  sqlite3 (>= 2.1)
+  stimulus-rails
+  tailwindcss-rails
+  thruster
+  turbo-rails
+  tzinfo-data
+  web-console
+
+CHECKSUMS
+  action_text-trix (2.1.18) sha256=3fdb83f8bff4145d098be283cdd47ac41caf5110bfa6df4695ed7127d7fb3642
+  actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0
+  actionmailbox (8.1.3) sha256=df7da474eaa0e70df4ed5a6fef66eb3b3b0f2dbf7f14518deee8d77f1b4aae59
+  actionmailer (8.1.3) sha256=831f724891bb70d0aaa4d76581a6321124b6a752cb655c9346aae5479318448d
+  actionpack (8.1.3) sha256=af998cae4d47c5d581a2cc363b5c77eb718b7c4b45748d81b1887b25621c29a3
+  actiontext (8.1.3) sha256=d291019c00e1ea9e6463011fa214f6081a56d7b9a1d224e7d3f6384c1dafc7d2
+  actionview (8.1.3) sha256=1347c88c7f3edb38100c5ce0e9fb5e62d7755f3edc1b61cce2eb0b2c6ea2fd5d
+  activejob (8.1.3) sha256=a149b1766aa8204c3c3da7309e4becd40fcd5529c348cffbf6c9b16b565fe8d3
+  activemodel (8.1.3) sha256=90c05cbe4cef3649b8f79f13016191ea94c4525ce4a5c0fb7ef909c4b91c8219
+  activerecord (8.1.3) sha256=8003be7b2466ba0a2a670e603eeb0a61dd66058fccecfc49901e775260ac70ab
+  activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
+  aws-partitions (1.1269.0) sha256=80beca6c8a35ddfc11b0b529424ea6167ace3da92cd7368847ce694679dedea5
+  aws-sdk-core (3.254.0) sha256=ee3e3220b8468a3c9e59daba18e6ec897bf5c7ce8adcc0670cfa2f1f092112fe
+  aws-sdk-rails (5.1.0) sha256=8cffd3b60142e12a6747c91a7a609f668276b1082fc0c10810d5da3d14b13189
+  aws-sdk-sns (1.118.0) sha256=46786eb1a27f8031163572043ed750cd292a1ca408527c5589ba5ecd43a0d2b9
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
+  bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
+  capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
+  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
+  erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
+  et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
+  fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
+  globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
+  importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
+  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  kamal (2.12.0) sha256=c51d1ab085e515470f98d0c0f043637122b5ebf76e8b610cb1fbbed0b7f9b8fa
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  local_time (3.0.3) sha256=c69a8974d993fdf6e60db02977ed23c070f203dcb3a1ff0de52ad3d2393f8303
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  mission_control-jobs (1.1.0) sha256=b13da9cde3344fec7c744b79d2a34c3ecd454f45d4d593d4c968ba762315e84c
+  msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
+  net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
+  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
+  net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d
+  net-sftp (4.0.0) sha256=65bb91c859c2f93b09826757af11b69af931a3a9155050f50d1b06d384526364
+  net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
+  net-ssh (7.3.3) sha256=831def58b2c51dcef66ec00d29397d4f210de89c19fe78f95873ca30f386e86a
+  nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
+  nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af
+  nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca
+  nokogiri (1.19.4-arm-linux-musl) sha256=588923c101bcfa78869734d247d25b598674323e7f22474fc468f6e5647311eb
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
+  nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  pagy (43.6.0) sha256=2ae1ff353f81a0ff8a0b20b163edfa751d7d21b786fa1aa496c4417bc1e5e7ab
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parser (3.3.10.0) sha256=ce3587fa5cc55a88c4ba5b2b37621b3329aadf5728f9eafa36bbd121462aabd6
+  pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
+  pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
+  pg (1.6.3-aarch64-linux-musl) sha256=06a75f4ea04b05140146f2a10550b8e0d9f006a79cdaf8b5b130cde40e3ecc2c
+  pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
+  pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
+  pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
+  psych (5.4.0) sha256=14f72d69a611af663d7d70e4a7b67d9eb1f3ae9f8d916b478961d5a0075ba5b7
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
+  raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
+  rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
+  rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
+  rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
+  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.82.1) sha256=09f1a6a654a960eda767aebea33e47603080f8e9c9a3f019bf9b94c9cab5e273
+  rubocop-ast (1.49.0) sha256=49c3676d3123a0923d333e20c6c2dbaaae2d2287b475273fddee0c61da9f71fd
+  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  rubocop-rails (2.34.2) sha256=10ff246ee48b25ffeabddc5fee86d159d690bb3c7b9105755a9c7508a11d6e22
+  rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  rubyzip (3.4.1) sha256=0a79e745b5c25872ebd148457df5665da8530ed8626c993b01457128f173ca02
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  selenium-webdriver (4.46.0) sha256=cb6cfa6f79eac041749df0b14cdcb0e9fe5df3715a64c77bfaa56b345b99f957
+  sessy-saas (0.1.0)
+  solid_cable (3.0.12) sha256=a168a54731a455d5627af48d8441ea3b554b8c1f6e6cd6074109de493e6b0460
+  solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
+  solid_queue (1.4.0) sha256=e6a18d196f0b27cb6e3c77c5b31258b05fb634f8ed64fb1866ed164047216c2a
+  sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
+  sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
+  sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b
+  sqlite3 (2.9.5-arm-linux-musl) sha256=bae1109d12b2e9f588455967729b008e1ff4feb7761749df695019c9079913c6
+  sqlite3 (2.9.5-arm64-darwin) sha256=d0cf444a70fc9395d513cfbcc1e6719e224aa645314e3824cb0474c721425aa2
+  sqlite3 (2.9.5-x86_64-linux-gnu) sha256=233dbcb6714148dd23bc5aeb33e8efd6eac974969564ddd5794c23d5f52b231e
+  sqlite3 (2.9.5-x86_64-linux-musl) sha256=e7d3a7474e8af0f96150c21abc203fbab5437206bfcdf11deab7741c0ca516f2
+  sshkit (1.25.0) sha256=c8c6543cdb60f91f1d277306d585dd11b6a064cb44eab0972827e4311ff96744
+  stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  tailwindcss-rails (4.6.0) sha256=d99512867173d55c5ef8890427682299d8539f550cec1408b3d8667a538bd365
+  tailwindcss-ruby (4.3.1) sha256=ced3198e057da98f21cb281f4821ac8882a2899047066895ba181caf312620c1
+  tailwindcss-ruby (4.3.1-aarch64-linux-gnu) sha256=b42af5fdb7ade3f3f70cda217c288986cc6b773601437b8deb80ea229a96680c
+  tailwindcss-ruby (4.3.1-aarch64-linux-musl) sha256=2854eec6704d5773346d44cf884944e1f90b1b195327e9cfa207cba614c024ab
+  tailwindcss-ruby (4.3.1-arm64-darwin) sha256=477ef19dde7fa4db32a0f916c02398e5fcc6af7f18d5e773012d93d6b96ecfa3
+  tailwindcss-ruby (4.3.1-x86_64-linux-gnu) sha256=22a208da614b7767cee504ab9dae2ab0d8299fdf633c045c6f8357de81d0506f
+  tailwindcss-ruby (4.3.1-x86_64-linux-musl) sha256=1adcb5df5f9a6a85a81dc9e5102ce7e4f7a1415f477f1a6b22b52ee49c351ee6
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  thruster (0.1.22) sha256=f34fb82bd3e31570ae8f8b930e484f9e1db7b080cbc993d49090b161879c3e05
+  thruster (0.1.22-aarch64-linux) sha256=6c306241e8ff8912fb26705a15cbb7b44a4dfcedd59fa890b2c72811f15cfa0e
+  thruster (0.1.22-arm64-darwin) sha256=d0506142832b1b020ab687dbfb938ec7cb07eeaabebc7f8682a73e8f0636917b
+  thruster (0.1.22-x86_64-linux) sha256=b96436be7f0854db632f421b4a53b795429a0bc95c15c2e1c1a7a6fdd1ed090f
+  timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
+  websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
+  websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
+  yaml (0.4.0) sha256=240e69d1e6ce3584d6085978719a0faa6218ae426e034d8f9b02fb54d3471942
+  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
+
+BUNDLED WITH
+  4.0.1

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -172,7 +172,7 @@ GEM
     lint_roller (1.1.0)
     local_time (3.0.3)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -284,8 +284,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -516,7 +516,7 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   local_time (3.0.3) sha256=c69a8974d993fdf6e60db02977ed23c070f203dcb3a1ff0de52ad3d2393f8303
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
@@ -564,7 +564,7 @@ CHECKSUMS
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Need help configuring AWS SES itself? See [AWS SES setup guide](docs/aws-ses-set
 
 For hardening recommendations, see [SES security and deliverability best practices](docs/ses-security-best-practices.md).
 
+## Hosted version
+
+We're working on a managed version of Sessy for those who'd rather not run their own instance.
+
+You'll notice references to it in this codebase: a `saas/` directory, `Gemfile.saas`, and the occasional `Sessy.saas?` check. These power the hosted version and are intentionally kept in this repository for simplicity, rather than maintaining separate repos. None of it affects self-hosting: the default bundle ignores the `saas/` engine entirely, and the test suite verifies the open-source version behaves identically without it.
+
 ## Jobs dashboard
 
 Sessy uses [Solid Queue](https://github.com/rails/solid_queue) for background jobs. A web dashboard is available at `/jobs` to monitor queues, retry failed jobs, and view recurring tasks.

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,6 +3,7 @@
     <%= link_to root_path, class: "flex items-center text-sm font-semibold", "aria-label": "Homepage" do %>
       <%= image_tag "wordmark.svg", class: "h-5 w-auto dark:invert", alt: "Sessy" %>
     <% end %>
+    <%= render "layouts/saas_badge" if Sessy.saas? %>
     <%= link_to "GitHub", "https://github.com/marckohlbrugge/sessy", target: "_blank", class: "text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100" %>
   </nav>
 </header>

--- a/bin/bundle-drift
+++ b/bin/bundle-drift
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+# Keeps Gemfile.saas.lock in sync with Gemfile.lock. Dependabot and manual
+# bundle updates only touch Gemfile.lock; this script carries the shared-gem
+# changes over to the SaaS lockfile.
+#
+#   bin/bundle-drift          repair drift and commit-ready the SaaS lockfile
+#   bin/bundle-drift --check  exit non-zero if drifted (used by CI)
+
+require "bundler"
+require "fileutils"
+
+def versions(lockfile)
+  Bundler::LockfileParser.new(File.read(lockfile)).specs.to_h { |spec| [ spec.name, spec.version.to_s ] }
+end
+
+SAAS_ONLY_GEMS = %w[ sessy-saas ]
+
+oss = versions("Gemfile.lock")
+saas = versions("Gemfile.saas.lock")
+
+drifted = (oss.keys & saas.keys).reject { |name| oss[name] == saas[name] }
+missing = oss.keys - saas.keys
+stale = saas.keys - oss.keys - SAAS_ONLY_GEMS
+
+if drifted.empty? && missing.empty? && stale.empty?
+  puts "Gemfile.saas.lock is in sync with Gemfile.lock"
+elsif ARGV.include?("--check")
+  drifted.each { |name| puts "#{name}: #{oss[name]} (Gemfile.lock) vs #{saas[name]} (Gemfile.saas.lock)" }
+  missing.each { |name| puts "#{name}: in Gemfile.lock but not in Gemfile.saas.lock" }
+  stale.each { |name| puts "#{name}: no longer in Gemfile.lock but still in Gemfile.saas.lock" }
+  abort "Gemfile.saas.lock has drifted from Gemfile.lock. Run bin/bundle-drift and commit the result."
+else
+  # Regenerate from Gemfile.lock so shared gems land on exactly its pins.
+  # A conservative `bundle lock` keeps every copied version and only resolves
+  # the sessy-saas path gem; `--update` would overshoot to latest-allowed.
+  FileUtils.cp "Gemfile.lock", "Gemfile.saas.lock"
+  system({ "BUNDLE_GEMFILE" => "Gemfile.saas" }, "bundle", "lock", exception: true)
+  puts "Regenerated Gemfile.saas.lock (#{(drifted + missing + stale).join(", ")})"
+end

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,10 @@ require "fileutils"
 
 APP_ROOT = File.expand_path("..", __dir__)
 
+# Mirror config/boot.rb: SESSY_MODE=saas selects the SaaS bundle for the
+# direct `bundle` calls below, which don't go through boot.rb.
+ENV["BUNDLE_GEMFILE"] ||= File.join(APP_ROOT, "Gemfile.saas") if ENV["SESSY_MODE"] == "saas"
+
 def system!(*args)
   system(*args, exception: true)
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path(ENV["SESSY_MODE"] == "saas" ? "../Gemfile.saas" : "../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -6,10 +6,16 @@ CI.run do
   step "Style: Ruby", "bin/rubocop"
 
   step "Security: Gem audit", "bin/bundler-audit"
+  step "Security: SaaS gem audit", "bin/bundler-audit check --gemfile-lock Gemfile.saas.lock"
   step "Security: Importmap vulnerability audit", "bin/importmap audit"
-  step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
+  step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error --add-engines-path saas"
+
+  step "Gemfile: Drift check", "bin/bundle-drift --check"
 
   step "Tests: Rails", "bin/rails test"
+  # bin/ci runs before Bundler.require, so Sessy.saas? can't see the engine
+  # here; the env var is the sanctioned pre-boot mode signal.
+  step "Tests: SaaS engine", "bin/rails test saas/test" if ENV["SESSY_MODE"] == "saas"
   step "Tests: System", "bin/rails test:system"
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -134,3 +134,21 @@ services:
 volumes:
   sessy:
 ```
+
+## Hosted edition (maintainer)
+
+The same Dockerfile builds the hosted edition, which layers the `saas/` engine via `Gemfile.saas`:
+
+```bash
+docker build --build-arg BUNDLE_GEMFILE=Gemfile.saas -t sessy-saas .
+```
+
+The build arg is promoted to a runtime `ENV`, so the container boots with the engine loaded — no extra runtime configuration needed. The default build (no arg) produces the open-source image with the `saas/` engine stripped out entirely; that is what `ghcr.io/marckohlbrugge/sessy` ships.
+
+For the Kamal-managed hosted instance, add the build arg to the (gitignored) `config/deploy.saas.yml`:
+
+```yaml
+builder:
+  args:
+    BUNDLE_GEMFILE: Gemfile.saas
+```

--- a/docs/plans/2026-07-17-001-feat-saas-engine-foundation-plan.md
+++ b/docs/plans/2026-07-17-001-feat-saas-engine-foundation-plan.md
@@ -1,0 +1,257 @@
+---
+title: SaaS Engine Foundation - Plan
+type: feat
+date: 2026-07-17
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# SaaS Engine Foundation - Plan
+
+## Goal Capsule
+
+- **Objective:** Establish the Fizzy-style OSS/SaaS boundary in Sessy — a vendored `saas/` Rails engine layered on via `Gemfile.saas`, opt-in through one env toggle, with zero behavior change for OSS users — proven by one small hosted-only behavior wired through the controller, route, and view seams.
+- **Authority:** This plan's Product Contract and Key Technical Decisions govern scope. Repo conventions (`AGENTS.md`, rubocop-rails-omakase, DHH-style concerns) govern style. User preferences override both.
+- **Stop conditions:** Stop and surface if implementation requires an engine database migration, a change to `config/database.yml`, or touching the untracked working-tree files (`config/deploy.sqlite.yml`, `.kamal/secrets.sqlite`, `.migration-backup/`, `wip.svg`) — each contradicts a decision below.
+- **Execution profile:** Standard feature branch (`marc/` prefix); commit/push/PR only with explicit user approval per user's global rules.
+
+---
+
+## Product Contract
+
+### Summary
+
+Add a `saas/` directory containing a `sessy-saas` Rails engine, loaded only when bundling with a new `Gemfile.saas`. `SESSY_MODE=saas` is the single developer-facing toggle; `Sessy.saas?` reports engine presence at runtime. The engine demonstrates its three extension seams (concern injection, appended routes, guarded view partials) with one migration-free hosted-only behavior. CI gains a SaaS leg, lockfile sync is automated, and the single Dockerfile learns to build either edition.
+
+### Problem Frame
+
+Sessy's open-source repo is its marketing channel; monetization will come from a hosted version with conveniences (managed setup, later billing/accounts). Basecamp's Fizzy solved the identical problem and its PR history (reviewed 2026-07-17) shows both the winning pattern — a vendored in-repo engine — and the detours to skip (separate private repo, single Gemfile with conditional groups). Nothing hosted-specific exists in Sessy's code today; the hosted instance at app.sessy.do is just the OSS app deployed with Postgres and HTTP Basic auth via a gitignored Kamal config. Before any hosted feature or billing work can start, the boundary itself must exist — and it must not complicate the OSS codebase that contributors and self-hosters touch.
+
+### Requirements
+
+**Mode and packaging**
+
+- R1. A fresh OSS clone behaves exactly as today: `bin/setup`, `bin/dev`, `bin/ci`, tests, and the public Docker image load no SaaS code and change no behavior.
+- R2. SaaS mode is opt-in via `SESSY_MODE=saas`, which routes bundling to `Gemfile.saas`; that gemfile layers the base `Gemfile` plus the vendored `sessy-saas` path gem.
+- R3. `Sessy.saas?` is true iff the engine is actually loaded, so no half-enabled state is reachable (engine loaded but flag false, or flag true but engine absent).
+
+**Extension seams**
+
+- R4. The engine extends the core app only through: `config.to_prepare` concern injection, routes appended by the engine's initializer, and engine-provided view partials rendered behind `if Sessy.saas?` guards. The core app carries no other SaaS logic.
+- R5. One hosted-only proof behavior exercises all three seams end-to-end and requires no database migration.
+
+**Contributor workflow and CI**
+
+- R6. CI runs the existing OSS matrix (SQLite + PostgreSQL) plus one SaaS leg (PostgreSQL) that runs the core suite and the engine's tests. The test legs run on fork PRs without secrets; the dependabot lockfile-sync workflow is the one secret-bearing exception and runs only on same-repo branches.
+- R7. `Gemfile.saas.lock` stays in sync with `Gemfile.lock` automatically on dependabot PRs, with a CI drift guard whose failure message tells a contributor exactly what to run.
+- R8. Security scanning covers the engine's code and the SaaS lockfile (brakeman engine paths, bundler-audit against both lockfiles).
+
+**Deployment**
+
+- R9. The single `Dockerfile` builds either edition via a build argument; the public `publish-image.yml` image remains pure OSS by default.
+
+### Scope Boundaries
+
+**Deferred to Follow-Up Work**
+
+- Accounts, users, and multi-tenancy (Sessy has no account model; `Source` is the top of the ownership graph — this is the next major piece for a hosted product).
+- Billing/subscriptions (Fizzy's removed Stripe implementation in basecamp/fizzy PRs #2050/#2175, deleted in #2712, is the reference when this starts).
+- Hosted product features: managed SNS setup, alerts, MCP.
+- Engine database migrations and the `saas`-database build-out — direction recorded in Key Technical Decisions; implementation deferred until the first hosted feature needs a table.
+- Additional engine seams real features will need — importmap-delivered engine JS/CSS, engine-contributed recurring jobs, and the data seam above. R4's v1 enumeration is expected to grow when the first stateful hosted feature lands.
+- Wiring the dormant `GitWorktree.db_suffix` mechanism (required by `config/database.yml` but referenced by neither adapter YAML).
+
+**Outside this product's identity**
+
+- Private/closed-source hosted code. The engine is public in this repo (user-confirmed); the O'Saasy license (`LICENSE.md`, already in place) is the guard against competing hosts. If genuinely secret code is ever needed, it enters as a private *gem dependency of the engine*, not a private repo split — Fizzy reversed its separate-repo split after three weeks (PR #2170: "extra paperwork, careful coordination, constant friction").
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **Vendored in-repo engine, not a separate repo or conditional Gemfile groups.** Fizzy tried both alternatives: the separate private repo was reversed in three weeks (#2170), and bundler groups were rejected because toggling modes dirties `Gemfile.lock` and bundler still resolves unreachable gems (#1697 review discussion). The end state — path gem in the public repo, separate lockfile — is the proven shape.
+- **Mode truth is engine presence; the env var is only a bootstrap convenience.** `Sessy.saas?` returns whether `Sessy::Saas` is defined (memoized with the `defined?(@saas)` pattern, since the common OSS answer is `false`). `SESSY_MODE=saas` is consumed only in pre-boot entry points where engine presence is unknowable — `config/boot.rb`'s `BUNDLE_GEMFILE` defaulting, `bin/setup`'s matching export, and the `config/ci.rb` step gate — so a stray env var on a self-hosted OSS bundle cannot flip runtime behavior (flow analysis critical gap: two independent toggles create half-on states in both directions). The name is namespaced (`SESSY_MODE`), never a generic `SAAS=1`. Engine internals need no mode gating: if the engine is loaded, SaaS mode is on by definition.
+- **`lib/sessy.rb` hosts the helper.** It already holds `Sessy.db_adapter` — the repo's existing dual-mode switch and the exact template. Zeitwerk constraint: `module Sessy` is shared with `Sessy::Application`; the engine's own code lives under the gem's `saas/lib/sessy/saas/`, keeping the host's `autoload_lib` untouched.
+- **Committed `Gemfile.saas.lock` with automated sync.** Dependabot's bundler ecosystem only updates the file literally named `Gemfile`, and CI installs frozen (setup-ruby `bundler-cache`, Bundler 4), so without automation every dependency bump fails the SaaS leg and kills automerge. Mechanism: a companion workflow regenerates `Gemfile.saas.lock` on dependabot PRs (Fizzy precedent: `dependabot-sync-saas-lockfile.yml`), plus a drift-check CI step. Fizzy also needed a manual fix for exactly this drift (#2722) — the automation is not optional.
+- **View seam uses `if Sessy.saas?` guards, not partial shadowing.** Rails engines *append* view paths — an engine cannot override a partial the app already has. So the pattern (Fizzy's too) is: core view renders an engine-namespaced partial only when `Sessy.saas?`; the partial file exists only in the engine.
+- **Proof behavior is migration-free by requirement.** Any engine migration would leak SaaS tables into the shared dev DB and the committed `db/schema.rb`, polluting every OSS `bin/setup` (flow analysis important gap).
+- **One parameterized Dockerfile.** `ARG BUNDLE_GEMFILE=Gemfile` promoted to `ENV`, with `Gemfile*` and `saas/` copied before `bundle install` (a path gem must be present at install). The default build is byte-for-byte OSS-equivalent in behavior; the hosted Kamal build passes the arg. Today's Dockerfile cannot produce a SaaS image at all (flow analysis critical gap).
+- **SaaS CI leg is single: PostgreSQL only**, matching the hosted instance (its gitignored deploy config runs Postgres). SQLite×SaaS adds cost without a production analog.
+- **Engine gemspec uses a static file glob, not `git ls-files`** — `.dockerignore` excludes `.git/`, so the conventional gemspec idiom breaks inside Docker builds.
+- **Engine tables, when they come, go in a separate `saas` database — recorded now, built later.** The first stateful hosted feature (accounts, billing) needs a data seam this foundation deliberately doesn't build. Direction on record so the boundary stays compatible: Fizzy's `SaasRecord` pattern — an abstract engine base class with `connects_to` a dedicated `saas` database whose migrations and schema live under `saas/db/`, keeping core `db/schema.rb` untouched for OSS users. Nothing in this plan constrains or contradicts that path.
+
+### High-Level Technical Design
+
+Mode resolution (boot-time) and the extension seams (runtime):
+
+```mermaid
+flowchart TB
+  ENV["SESSY_MODE=saas set?"] -->|no| G1["BUNDLE_GEMFILE defaults to Gemfile"]
+  ENV -->|yes| G2["config/boot.rb defaults BUNDLE_GEMFILE to Gemfile.saas"]
+  EXPL["Explicit BUNDLE_GEMFILE (Docker ENV, CI job env)"] -->|overrides both| B
+  G1 --> B["bundler/setup"]
+  G2 --> B
+  B -->|Gemfile| OSS["No engine in bundle — Sessy.saas? == false"]
+  B -->|Gemfile.saas| SAAS["Bundler.require loads sessy-saas engine — Sessy.saas? == true"]
+```
+
+```mermaid
+flowchart TB
+  subgraph engine ["saas/ (sessy-saas engine)"]
+    INIT["engine initializer"]
+    TP["config.to_prepare"]
+    VP["engine view partials"]
+    EC["engine controllers + routes"]
+  end
+  subgraph core ["core app (unchanged behavior in OSS)"]
+    AC["ApplicationController"]
+    HDR["layouts/_header partial"]
+    RT["config/routes.rb"]
+  end
+  TP -->|"include concern"| AC
+  INIT -->|"app.routes.append"| RT
+  HDR -->|"render ... if Sessy.saas?"| VP
+  RT -.->|"appended routes dispatch to"| EC
+```
+
+### Sources and Research
+
+- Fizzy architecture and history: basecamp/fizzy PRs #1697 (the split), #2170 (repatriation), #2712 (billing removal), #2722 (lockfile drift), #2677 (middleware leak → security advisory); current-repo mechanisms (`lib/fizzy.rb`, `Gemfile.saas`, `saas/lib/fizzy/saas/engine.rb`, `bin/bundle-drift`, CI split). Reviewed in depth 2026-07-17.
+- Repo grounding: `lib/sessy.rb` (`db_adapter` pattern), `config/database.yml` (ERB mode dispatch), `config/boot.rb` (`BUNDLE_GEMFILE ||=` seam), `.github/workflows/ci.yml` (adapter matrix), `Dockerfile:39` (COPY ordering), `config/ci.rb` (Rails 8.1 CI DSL), `test/helpers/application_helper_test.rb` (`with_env` pattern), `.gitignore` (reserves `/config/deploy.saas.yml` and `/.kamal/secrets.saas` — anchored rules, no collision with tracked `saas/`).
+
+---
+
+## Output Structure
+
+```
+Gemfile.saas
+Gemfile.saas.lock
+saas/
+├── sessy-saas.gemspec
+├── LICENSE.md
+├── README.md
+├── lib/
+│   └── sessy/
+│       ├── saas.rb
+│       └── saas/
+│           ├── engine.rb
+│           └── version.rb
+├── app/
+│   ├── controllers/sessy/saas/           (proof controller)
+│   ├── controllers/concerns/sessy/saas/  (injected concern)
+│   └── views/                            (badge partial, proof view)
+├── config/
+│   └── routes.rb
+└── test/
+    └── (engine tests, using the host test_helper)
+```
+
+The tree is a scope declaration; per-unit `Files` lists are authoritative.
+
+---
+
+## Implementation Units
+
+### U1. Mode helper, Gemfile.saas, and engine skeleton
+
+- **Goal:** SaaS mode exists and is inert-by-default: `Sessy.saas?`, `Gemfile.saas` + lockfile, and a loadable empty engine.
+- **Requirements:** R1, R2, R3
+- **Dependencies:** none
+- **Files:** `lib/sessy.rb`, `config/boot.rb`, `bin/setup`, `Gemfile.saas`, `Gemfile.saas.lock`, `saas/sessy-saas.gemspec`, `saas/lib/sessy/saas.rb`, `saas/lib/sessy/saas/engine.rb`, `saas/lib/sessy/saas/version.rb`, `saas/LICENSE.md`, `saas/README.md`, `test/models/sessy_test.rb`
+- **Approach:** `Sessy.saas?` in `lib/sessy.rb` reports `defined?(Sessy::Saas)` presence, memoized with a `defined?(@saas)` guard. `config/boot.rb` picks `Gemfile.saas` in its existing `BUNDLE_GEMFILE ||=` line when `SESSY_MODE=saas` (explicit `BUNDLE_GEMFILE` still wins — Docker and CI set it directly). `bin/setup` invokes `bundle` directly and bypasses boot.rb, so it exports `BUNDLE_GEMFILE` from `SESSY_MODE` the same way — one variable drives every entry point. `Gemfile.saas` does `eval_gemfile "Gemfile"` then `gem "sessy-saas", path: "saas"`. Gemspec: static file glob; license O'Saasy matching root. Engine class `Sessy::Saas::Engine < ::Rails::Engine` with no hooks yet.
+- **Patterns to follow:** `Sessy.db_adapter` in `lib/sessy.rb` (memoized env-driven value); Fizzy's `Gemfile.saas` shape.
+- **Test scenarios:**
+  - Happy path: `Sessy.saas?` returns false in the OSS suite; returns true in the SaaS suite (asserted from the engine's own tests in U2, run via U3's infrastructure).
+  - Edge: with `SESSY_MODE=saas` but an explicit `BUNDLE_GEMFILE` pointing at the plain `Gemfile`, boot proceeds in OSS mode and `Sessy.saas?` is false (no half-on state).
+  - Edge: memoization — repeated calls return a stable value; the false case does not re-evaluate (guarded by `defined?`).
+  - Test expectation for `Gemfile.saas`/gemspec wiring: covered by `bundle check` succeeding in the SaaS CI leg rather than unit tests.
+- **Verification:** OSS suite green with zero diff in behavior; `BUNDLE_GEMFILE=Gemfile.saas bundle install` resolves the path gem; `SESSY_MODE=saas bin/rails runner "p Sessy.saas?"` prints true, plain prints false; `SESSY_MODE=saas bin/setup --skip-server` completes against the SaaS bundle.
+
+### U2. Proof behavior through all three seams
+
+- **Goal:** One migration-free hosted-only behavior demonstrates concern injection, appended routes, and guarded views — the controller, route, and view seams future hosted features will share.
+- **Requirements:** R4, R5
+- **Dependencies:** U1
+- **Files:** `saas/lib/sessy/saas/engine.rb`, `saas/app/controllers/concerns/sessy/saas/edition_headers.rb`, `saas/app/controllers/sessy/saas/infos_controller.rb`, `saas/config/routes.rb`, `saas/app/views/sessy/saas/infos/show.html.erb`, `saas/app/views/layouts/_saas_badge.html.erb`, `app/views/layouts/_header.html.erb`, `saas/test/controllers/edition_headers_test.rb`, `saas/test/controllers/infos_test.rb`, `test/integration/oss_mode_test.rb`
+- **Approach:** Three seams, one feature ("hosted edition visibility"):
+  1. *Concern injection:* engine's `config.to_prepare` includes `Sessy::Saas::EditionHeaders` into `ApplicationController`, adding an `X-Sessy-Edition: hosted` response header — trivially assertable at controller level in both modes.
+  2. *Routes:* engine initializer does `app.routes.append { mount Sessy::Saas::Engine ... }` (or appends a named route) exposing a small hosted-info page (engine version, Rails env) — useful for verifying hosted deploys. Appended routes cannot shadow core routes; anything that must win over core would need `prepend` (not needed here — note for future features).
+  3. *Guarded view:* `layouts/_header.html.erb` renders the engine's badge partial behind `if Sessy.saas?` — the only core-view change.
+  The core-app diff for this unit is exactly one guarded render line; that is the leakage budget working as intended.
+- **Patterns to follow:** Fizzy's `saas/lib/fizzy/saas/engine.rb` (`to_prepare` includes, self-mounting initializer); Sessy's nested-concern style (`Event::Filterable`).
+- **Test scenarios (engine suite, SaaS mode):**
+  - Happy path: any core page response carries `X-Sessy-Edition: hosted`; the info route renders 200 with the engine version; the header partial contains the badge.
+  - Integration: the injected concern survives reload (`to_prepare`, not `initializer`) — assert inclusion after `Rails.application.reloader.reload!` or equivalent in a controller test hitting two sequential requests in development-like reloading (if impractical in test env, assert `ApplicationController.include?(Sessy::Saas::EditionHeaders)`).
+- **Test scenarios (OSS suite):**
+  - Regression guard: responses carry no `X-Sessy-Edition` header; the info route does not resolve (404/RoutingError); rendered header HTML contains no badge. This is the cheap enforcement of R1's "zero behavior change" promise. These tests `skip if Sessy.saas?` so the core suite stays green when the SaaS CI leg runs it.
+- **Verification:** both suites green; manually boot each mode and eyeball the header (screenshot per user's debugging rule).
+
+### U3. Test infrastructure for both modes
+
+- **Goal:** The engine has a test home that reuses the host harness, and each mode has a one-command local run.
+- **Requirements:** R1, R6
+- **Dependencies:** U1, U2
+- **Files:** `config/ci.rb`, `test/test_helper.rb` (only if a shared helper needs promoting), `AGENTS.md`
+- **Approach:** Engine tests (created in U2, under `saas/test/`) `require "test_helper"` against the host's `test/test_helper.rb` — no dummy app (host-app testing is the Fizzy model). Local commands: `bin/rails test` (OSS), `SESSY_MODE=saas bin/rails test test saas/test` (SaaS, core suite plus engine suite). `config/ci.rb` gains a conditional step gated on `ENV["SESSY_MODE"] == "saas"`: also run `saas/test`, making `SESSY_MODE=saas bin/ci` the full local SaaS pipeline. The gate must be the env var, not `Sessy.saas?` — `bin/ci` runs before `Bundler.require`, so neither the helper nor the engine exists in that process; this is a sanctioned pre-boot consumer of `SESSY_MODE` (see the mode-truth decision). Mode is fixed per process (memoized helper + env at boot): SaaS-mode coverage runs as a separate suite invocation, never as in-process env toggling. Document both commands in `AGENTS.md`, along with the contributor policy: SaaS-leg failures on external PRs are the maintainer's responsibility to fix, not the contributor's.
+- **Patterns to follow:** `config/ci.rb`'s existing step list; Fizzy's `append_test_paths`/host-suite-in-saas-mode CI principle (#2029).
+- **Test scenarios:** This unit is harness/config; its proof is U2's suites executing in both modes. Test expectation: none beyond that — config wiring is verified by the commands running.
+- **Verification:** `bin/ci` (OSS) and `SESSY_MODE=saas bin/ci` both pass locally end-to-end.
+
+### U4. CI workflows: SaaS leg, lockfile sync, scan coverage
+
+- **Goal:** CI proves both modes on every PR (fork-safe), lockfile drift is impossible to merge, and scans cover the engine.
+- **Requirements:** R6, R7, R8
+- **Dependencies:** U3
+- **Files:** `.github/workflows/ci.yml`, `.github/workflows/sync-saas-lockfile.yml` (new), `bin/bundle-drift` (new)
+- **Approach:** Add one matrix include to the `test` job: SaaS + PostgreSQL, with job-level `BUNDLE_GEMFILE: Gemfile.saas` and `SESSY_MODE: saas` (setup-ruby's `bundler-cache` keys off the active gemfile's lock). Its steps run the core suite plus `saas/test`. Drift guard: `bin/bundle-drift`, a check-and-repair script — it names the shared gems whose versions diverge between the two lockfiles and repairs with `BUNDLE_GEMFILE=Gemfile.saas bundle lock --update=<those gems>` (plain `bundle lock` is a no-op here: without `--update`, bundler preserves existing valid pins). CI runs it in check mode; its failure message says to run `bin/bundle-drift`. Sync workflow: on dependabot PRs touching `Gemfile.lock`, run `bin/bundle-drift` and push the regenerated lock to the PR branch (Fizzy's `dependabot-sync-saas-lockfile.yml` is the template). The push must authenticate with a fine-grained PAT (contents: write) stored as both an Actions and a Dependabot secret — commits pushed with the default `GITHUB_TOKEN` trigger no workflow runs (required checks would hang and `automerge.yml` would never fire), and dependabot-context runs get a read-only default token. The workflow runs only on same-repo dependabot branches; fork-PR test legs still need no secrets (R6). Scans: `scan_ruby` adds `--add-engines-path saas` to brakeman and `bin/bundler-audit --gemfile-lock Gemfile.saas.lock` as a second audit (bundler-audit selects its lockfile via that flag and ignores `BUNDLE_GEMFILE`).
+- **Patterns to follow:** existing `ci.yml` matrix-include shape and Postgres `services:` block; `automerge.yml`'s required-checks dependency.
+- **Test scenarios:** CI-config unit — verified by runs, not unit tests:
+  - Fork-PR simulation: the SaaS leg needs no secrets (it must not reference any).
+  - Drift simulation: bump a gem version in `Gemfile.lock` only; the drift step fails with the documented message; running `bin/bundle-drift` repairs it.
+  - Dependabot simulation: a branch touching only `Gemfile`/`Gemfile.lock` gets a synced `Gemfile.saas.lock` commit from the workflow, and CI runs on the synced commit SHA (the PAT push triggers it; a `GITHUB_TOKEN` push would not).
+- **Verification:** a PR run shows all four test legs green (SQLite, PostgreSQL, SaaS+PostgreSQL, plus scans/lint); drift and sync behaviors demonstrated as above.
+
+### U5. Dockerfile parameterization and hosted deploy notes
+
+- **Goal:** One Dockerfile builds either edition; the public image stays OSS; the hosted Kamal deploy has documented settings to actually ship the SaaS build.
+- **Requirements:** R1, R9
+- **Dependencies:** U1
+- **Files:** `Dockerfile`, `docs/docker-deployment.md`, `README.md`
+- **Approach:** `ARG BUNDLE_GEMFILE=Gemfile` promoted to `ENV BUNDLE_GEMFILE` (so runtime boot, `bootsnap precompile --gemfile`, and `assets:precompile` all follow it); the pre-`bundle install` layer copies `Gemfile Gemfile.lock Gemfile.saas Gemfile.saas.lock vendor` and adds a separate `COPY saas saas/` instruction — multi-source `COPY ... ./` flattens directory contents, which would leave no `saas/` directory at the path the lockfile expects (path gems must exist at install). Default build arg keeps the OSS image and `publish-image.yml` unchanged. Because mode truth is engine presence (U1), no `SESSY_MODE` runtime env is needed in the image. The hosted deploy change — `builder.args.BUNDLE_GEMFILE: Gemfile.saas` in `config/deploy.saas.yml` — lives in a gitignored file, so the plan's deliverable is the documented snippet (in `docs/docker-deployment.md` or a new short `docs/saas-mode.md` section), applied manually by the maintainer.
+- **Patterns to follow:** existing Dockerfile stage layout and `bin/docker-entrypoint`; Fizzy's per-mode Docker approach (it uses a separate `saas/Dockerfile`; we deliberately parameterize the one file instead, since our engine has no divergent base image needs).
+- **Test scenarios:** Docker/config unit — verified by builds:
+  - `docker build .` (no arg) produces an image whose booted container reports `Sessy.saas?` false and serves no `X-Sessy-Edition` header.
+  - `docker build --build-arg BUNDLE_GEMFILE=Gemfile.saas .` boots with the engine loaded, serves the header and info route.
+- **Verification:** both builds succeed locally and the runtime smoke checks above pass (`docker run` + curl).
+- **Execution note:** This is packaging/config; prefer the build-and-smoke verification above over unit coverage.
+
+---
+
+## Verification Contract
+
+| Check | Command | Applies to |
+|---|---|---|
+| OSS test suite | `bin/rails test` and `bin/rails test:system` | U1, U2, U3 |
+| SaaS test suite | `SESSY_MODE=saas bin/rails test test saas/test` | U1, U2, U3 |
+| Full local pipeline, both modes | `bin/ci` and `SESSY_MODE=saas bin/ci` | U3, U4 |
+| Lint | `bin/rubocop` | all |
+| Security | `bin/brakeman --add-engines-path saas`, `bin/bundler-audit`, `bin/bundler-audit --gemfile-lock Gemfile.saas.lock` | U4 |
+| Docker smoke | `docker build` with and without `--build-arg BUNDLE_GEMFILE=Gemfile.saas`, boot + curl for `X-Sessy-Edition` | U5 |
+| Zero-OSS-change gate | OSS-suite regression tests from U2 (no header, no route, no badge) | U2 |
+
+Quality gates: all four CI legs green on the PR; `db/schema.rb` diffed against main before opening the PR (user's standing rule; also enforces the migration-free decision).
+
+---
+
+## Definition of Done
+
+- All five units implemented and verified per their Verification lines; both `bin/ci` invocations pass locally.
+- OSS mode is behavior-identical: U2's regression tests pass and `db/schema.rb` has no diff against main.
+- CI on the PR shows the SaaS leg, drift guard, and extended scans green without any secrets.
+- Docs updated: `AGENTS.md` (dev commands for both modes), deployment doc snippet for the hosted Kamal config.
+- No stray scope: untracked working-tree files (`config/deploy.sqlite.yml`, `.kamal/secrets.sqlite`, `.migration-backup/`, `wip.svg`) untouched and unstaged; no experimental/dead-end code left in the diff.
+- Operational follow-ups surfaced to the maintainer (not performed by the implementer): add the SaaS CI leg to branch-protection required checks so `automerge.yml` respects it; create the fine-grained PAT (contents: write) for the lockfile-sync workflow and store it as both an Actions and a Dependabot secret; apply the documented `builder.args` change to the local gitignored `config/deploy.saas.yml` on the next hosted deploy.

--- a/lib/sessy.rb
+++ b/lib/sessy.rb
@@ -7,6 +7,14 @@ module Sessy
         }
       )
     end
+
+    # True when the sessy-saas engine is in the bundle (Gemfile.saas). The
+    # SESSY_MODE env var only selects the gemfile in pre-boot entry points;
+    # at runtime, engine presence is the single source of truth.
+    def saas?
+      return @saas if defined?(@saas)
+      @saas = defined?(Sessy::Saas) ? true : false
+    end
   end
 
   class DbAdapter

--- a/saas/LICENSE.md
+++ b/saas/LICENSE.md
@@ -1,0 +1,10 @@
+# O'Saasy License Agreement
+
+Copyright © 2025, Killbridge Ventures Pte. Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+2. No licensee or downstream recipient may use the Software (including any modified or derivative versions) to directly compete with the original Licensor by offering it to third parties as a hosted, managed, or Software-as-a-Service (SaaS) product or cloud service where the primary value of the service is the functionality of the Software itself.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/saas/LICENSE.md
+++ b/saas/LICENSE.md
@@ -1,6 +1,6 @@
 # O'Saasy License Agreement
 
-Copyright © 2025, Killbridge Ventures Pte. Ltd.
+Copyright © 2026, Killbridge Ventures Pte. Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/saas/README.md
+++ b/saas/README.md
@@ -1,0 +1,5 @@
+# sessy-saas
+
+Companion Rails engine for the hosted version of [Sessy](https://github.com/marckohlbrugge/sessy). It is loaded only when bundling with `Gemfile.saas` (`SESSY_MODE=saas` in development) and holds everything specific to the hosted edition, keeping the open-source app free of hosted-only code.
+
+This engine is not meant to be used by third parties — the [O'Saasy license](LICENSE.md) does not permit offering Sessy as a competing hosted service — but it can serve as inspiration for anyone running Sessy on their own infrastructure.

--- a/saas/app/controllers/concerns/sessy/saas/edition_headers.rb
+++ b/saas/app/controllers/concerns/sessy/saas/edition_headers.rb
@@ -1,0 +1,14 @@
+module Sessy::Saas::EditionHeaders
+  extend ActiveSupport::Concern
+
+  included do
+    # Prepended so the header is stamped even when a later callback halts
+    # the chain (e.g. HTTP Basic auth rejecting with a 401).
+    prepend_before_action :set_edition_header
+  end
+
+  private
+    def set_edition_header
+      response.set_header "X-Sessy-Edition", "hosted"
+    end
+end

--- a/saas/app/controllers/sessy/saas/infos_controller.rb
+++ b/saas/app/controllers/sessy/saas/infos_controller.rb
@@ -1,0 +1,4 @@
+class Sessy::Saas::InfosController < ApplicationController
+  def show
+  end
+end

--- a/saas/app/views/layouts/_saas_badge.html.erb
+++ b/saas/app/views/layouts/_saas_badge.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Hosted", saas_info_path, data: { saas_badge: true }, class: "text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100" %>

--- a/saas/app/views/sessy/saas/infos/show.html.erb
+++ b/saas/app/views/sessy/saas/infos/show.html.erb
@@ -1,0 +1,14 @@
+<div class="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+  <h1 class="text-2xl font-semibold">Sessy hosted edition</h1>
+
+  <dl class="mt-4 space-y-1 text-sm text-zinc-500 dark:text-zinc-400">
+    <div class="flex gap-2">
+      <dt>Engine version</dt>
+      <dd><%= Sessy::Saas::VERSION %></dd>
+    </div>
+    <div class="flex gap-2">
+      <dt>Environment</dt>
+      <dd><%= Rails.env %></dd>
+    </div>
+  </dl>
+</div>

--- a/saas/lib/sessy-saas.rb
+++ b/saas/lib/sessy-saas.rb
@@ -1,0 +1,1 @@
+require_relative "sessy/saas"

--- a/saas/lib/sessy/saas.rb
+++ b/saas/lib/sessy/saas.rb
@@ -1,0 +1,7 @@
+require_relative "saas/version"
+require_relative "saas/engine"
+
+module Sessy
+  module Saas
+  end
+end

--- a/saas/lib/sessy/saas/engine.rb
+++ b/saas/lib/sessy/saas/engine.rb
@@ -1,0 +1,15 @@
+module Sessy
+  module Saas
+    class Engine < ::Rails::Engine
+      initializer "sessy_saas.routes" do |app|
+        app.routes.append do
+          resource :saas_info, only: :show, controller: "sessy/saas/infos", path: "saas/info"
+        end
+      end
+
+      config.to_prepare do
+        ApplicationController.include Sessy::Saas::EditionHeaders
+      end
+    end
+  end
+end

--- a/saas/lib/sessy/saas/version.rb
+++ b/saas/lib/sessy/saas/version.rb
@@ -1,0 +1,5 @@
+module Sessy
+  module Saas
+    VERSION = "0.1.0"
+  end
+end

--- a/saas/sessy-saas.gemspec
+++ b/saas/sessy-saas.gemspec
@@ -1,0 +1,18 @@
+require_relative "lib/sessy/saas/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "sessy-saas"
+  spec.version = Sessy::Saas::VERSION
+  spec.authors = [ "Marc Köhlbrugge" ]
+  spec.summary = "Hosted-edition companion engine for Sessy"
+  spec.description = "Rails engine that bundles with Sessy to power the hosted version. Not meant to be used by third parties, but it can serve as inspiration for running Sessy on your own infrastructure."
+  spec.homepage = "https://github.com/marckohlbrugge/sessy"
+  spec.license = "Nonstandard"
+  spec.required_ruby_version = ">= 3.4"
+
+  # Static glob, not `git ls-files`: this gemspec must also resolve inside
+  # Docker builds, where .dockerignore excludes the .git directory.
+  spec.files = Dir["{app,config,lib}/**/*", "LICENSE.md", "README.md"]
+
+  spec.add_dependency "rails", ">= 8.1"
+end

--- a/saas/test/controllers/edition_headers_test.rb
+++ b/saas/test/controllers/edition_headers_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Sessy::Saas::EditionHeadersTest < ActionDispatch::IntegrationTest
+  test "responses carry the hosted edition header" do
+    get root_path
+    assert_response :success
+    assert_equal "hosted", response.headers["X-Sessy-Edition"]
+  end
+
+  test "concern is wired via to_prepare" do
+    assert ApplicationController.include?(Sessy::Saas::EditionHeaders)
+  end
+
+  test "auth challenges carry the edition header" do
+    ENV["HTTP_AUTH_USERNAME"] = "user"
+    ENV["HTTP_AUTH_PASSWORD"] = "secret"
+    get root_path
+    assert_response :unauthorized
+    assert_equal "hosted", response.headers["X-Sessy-Edition"]
+  ensure
+    ENV.delete("HTTP_AUTH_USERNAME")
+    ENV.delete("HTTP_AUTH_PASSWORD")
+  end
+end

--- a/saas/test/controllers/infos_test.rb
+++ b/saas/test/controllers/infos_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Sessy::Saas::InfosTest < ActionDispatch::IntegrationTest
+  test "info page shows the engine version" do
+    get saas_info_path
+    assert_response :success
+    assert_match Sessy::Saas::VERSION, response.body
+  end
+
+  test "header shows the hosted badge" do
+    get root_path
+    assert_select "[data-saas-badge]"
+  end
+end

--- a/test/bundle_drift_test.rb
+++ b/test/bundle_drift_test.rb
@@ -33,7 +33,11 @@ class BundleDriftTest < ActiveSupport::TestCase
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, "Gemfile.lock"), lockfile(oss))
         File.write(File.join(dir, "Gemfile.saas.lock"), lockfile(saas))
-        out = IO.popen([ RbConfig.ruby, Rails.root.join("bin/bundle-drift").to_s, "--check" ], chdir: dir, err: [ :child, :out ], &:read)
+        # Unbundled env: CI's job-level RUBYOPT/BUNDLE_GEMFILE would otherwise
+        # make the child resolve a Gemfile relative to the temp dir and crash.
+        out = Bundler.with_unbundled_env do
+          IO.popen([ RbConfig.ruby, Rails.root.join("bin/bundle-drift").to_s, "--check" ], chdir: dir, err: [ :child, :out ], &:read)
+        end
         [ out, $? ]
       end
     end

--- a/test/bundle_drift_test.rb
+++ b/test/bundle_drift_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+# Exercises bin/bundle-drift's --check classification against fixture
+# lockfiles in a temp directory. The repair branch shells out to bundler
+# with network access, so it stays covered by CI usage rather than tests.
+class BundleDriftTest < ActiveSupport::TestCase
+  test "in sync when saas lock only adds the engine" do
+    out, status = run_check(oss: { "foo" => "1.0.0" }, saas: { "foo" => "1.0.0", "sessy-saas" => "0.1.0" })
+    assert status.success?, out
+    assert_match(/in sync/, out)
+  end
+
+  test "flags a version drift by gem name" do
+    out, status = run_check(oss: { "foo" => "1.1.0" }, saas: { "foo" => "1.0.0", "sessy-saas" => "0.1.0" })
+    assert_not status.success?
+    assert_match(/foo: 1\.1\.0 \(Gemfile\.lock\) vs 1\.0\.0/, out)
+  end
+
+  test "flags a gem missing from the saas lock" do
+    out, status = run_check(oss: { "foo" => "1.0.0", "bar" => "2.0.0" }, saas: { "foo" => "1.0.0", "sessy-saas" => "0.1.0" })
+    assert_not status.success?
+    assert_match(/bar: in Gemfile\.lock but not in Gemfile\.saas\.lock/, out)
+  end
+
+  test "flags a stale gem removed from Gemfile.lock" do
+    out, status = run_check(oss: { "foo" => "1.0.0" }, saas: { "foo" => "1.0.0", "bar" => "2.0.0", "sessy-saas" => "0.1.0" })
+    assert_not status.success?
+    assert_match(/bar: no longer in Gemfile\.lock but still in Gemfile\.saas\.lock/, out)
+  end
+
+  private
+    def run_check(oss:, saas:)
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "Gemfile.lock"), lockfile(oss))
+        File.write(File.join(dir, "Gemfile.saas.lock"), lockfile(saas))
+        out = IO.popen([ RbConfig.ruby, Rails.root.join("bin/bundle-drift").to_s, "--check" ], chdir: dir, err: [ :child, :out ], &:read)
+        [ out, $? ]
+      end
+    end
+
+    def lockfile(gems)
+      specs = gems.map { |name, version| "    #{name} (#{version})" }.join("\n")
+      dependencies = gems.keys.map { |name| "  #{name}" }.join("\n")
+      <<~LOCKFILE
+        GEM
+          remote: https://rubygems.org/
+          specs:
+        #{specs}
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+        #{dependencies}
+
+        BUNDLED WITH
+           2.7.2
+      LOCKFILE
+    end
+end

--- a/test/integration/oss_mode_test.rb
+++ b/test/integration/oss_mode_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+# Guards R1: with the plain Gemfile, no SaaS behavior is reachable.
+class OssModeTest < ActionDispatch::IntegrationTest
+  setup do
+    skip "sessy-saas engine is loaded" if Sessy.saas?
+  end
+
+  test "responses carry no edition header" do
+    get root_path
+    assert_response :success
+    assert_nil response.headers["X-Sessy-Edition"]
+  end
+
+  test "saas info route does not resolve" do
+    get "/saas/info"
+    assert_response :not_found
+  end
+
+  test "header contains no hosted badge" do
+    get root_path
+    assert_select "[data-saas-badge]", count: 0
+  end
+end

--- a/test/models/sessy_test.rb
+++ b/test/models/sessy_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class SessyTest < ActiveSupport::TestCase
+  test "saas? reflects engine presence" do
+    if defined?(Sessy::Saas)
+      assert Sessy.saas?
+    else
+      assert_not Sessy.saas?
+    end
+  end
+
+  test "saas? is memoized" do
+    original = Sessy.saas?
+    Sessy.instance_variable_set(:@saas, :sentinel)
+    assert_equal :sentinel, Sessy.saas?
+  ensure
+    Sessy.instance_variable_set(:@saas, original)
+  end
+end
+
+# config/boot.rb resolves BUNDLE_GEMFILE from SESSY_MODE before Bundler runs.
+# Exercised in a subprocess (the resolution is frozen in this process), with
+# bundler/setup and bootsnap/setup stubbed out so only the env logic runs.
+class SessyModeSelectionTest < ActiveSupport::TestCase
+  test "SESSY_MODE=saas selects Gemfile.saas" do
+    assert_equal "Gemfile.saas", resolved_gemfile("SESSY_MODE" => "saas")
+  end
+
+  test "no SESSY_MODE selects Gemfile" do
+    assert_equal "Gemfile", resolved_gemfile({})
+  end
+
+  test "explicit BUNDLE_GEMFILE wins over SESSY_MODE" do
+    assert_equal "Gemfile", resolved_gemfile("SESSY_MODE" => "saas", "BUNDLE_GEMFILE" => Rails.root.join("Gemfile").to_s)
+  end
+
+  private
+    STUB_REQUIRES = <<~RUBY
+      module Kernel
+        alias_method :__original_require, :require
+        def require(name)
+          return true if %w[ bundler/setup bootsnap/setup ].include?(name)
+          __original_require(name)
+        end
+      end
+    RUBY
+
+    def resolved_gemfile(env)
+      # Spawned with the bundler environment stripped: the parent test process
+      # runs under bundler, whose env vars re-resolve BUNDLE_GEMFILE in child
+      # processes before boot.rb gets the chance.
+      env = { "SESSY_MODE" => nil, "BUNDLE_GEMFILE" => nil }.merge(env)
+      script = "#{STUB_REQUIRES}; load #{Rails.root.join("config/boot.rb").to_s.inspect}; puts File.basename(ENV[\"BUNDLE_GEMFILE\"])"
+      Bundler.with_unbundled_env do
+        IO.popen(env, [ RbConfig.ruby, "-e", script ], &:read).strip
+      end
+    end
+end


### PR DESCRIPTION
## Summary

Establishes the OSS/SaaS boundary (modeled on basecamp/fizzy): a vendored `saas/` Rails engine loaded only when bundling with `Gemfile.saas`. The open-source app carries no hosted-only code — `Sessy.saas?` reports engine presence, and OSS regression tests pin the zero-behavior-change guarantee.

- `SESSY_MODE=saas` selects the SaaS bundle in the pre-boot entry points (`config/boot.rb`, `bin/setup`, `bin/ci`); at runtime, engine presence is the single source of truth
- Proof feature through the three extension seams: `X-Sessy-Edition` response header (`to_prepare` concern injection), `/saas/info` page (engine-appended route), header badge (one guarded render line — the only core-view change)
- CI: SaaS+PostgreSQL matrix leg (fork-safe, no secrets), `bin/bundle-drift` lockfile check/repair, dependabot lockfile-sync workflow, engine-aware brakeman + second bundler-audit
- One Dockerfile builds either edition via `--build-arg BUNDLE_GEMFILE=Gemfile.saas`; the default build strips `saas/` so the public image ships without the hosted engine

## Non-obvious details

- `bin/bundle-drift` repair regenerates `Gemfile.saas.lock` from `Gemfile.lock` with a conservative `bundle lock` — `--update` resolves to latest-allowed and overshoots the pins (empirically verified)
- The sync workflow pushes with a PAT because `GITHUB_TOKEN` pushes trigger no workflow runs (required checks would hang) and dependabot-context runs get a read-only token
- The edition header uses `prepend_before_action` so halted chains (HTTP Basic 401s) still carry it
- `config/ci.rb` gates the engine-test step on `ENV["SESSY_MODE"]` — `bin/ci` runs before `Bundler.require`, so `Sessy.saas?` is unavailable there

## Post-merge / operational

- [ ] Create a fine-grained PAT (contents: write, this repo only) and store it as `SAAS_LOCKFILE_SYNC_TOKEN` in **both** Actions and Dependabot secrets — without it, dependabot PRs will fail the drift check
- [ ] Add `test (PostgreSQL SaaS)` to branch-protection required checks so automerge respects it
- [ ] Add `builder.args.BUNDLE_GEMFILE: Gemfile.saas` to the local gitignored `config/deploy.saas.yml` before the next hosted deploy (snippet in `docs/docker-deployment.md`)

Plan: `docs/plans/2026-07-17-001-feat-saas-engine-foundation-plan.md`