### PR TITLE
Add hosted Sessy launch: multi-tenant accounts, magic-code auth, approval

### DIFF
--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -1,3 +1,7 @@
 eval_gemfile "Gemfile"
 
 gem "sessy-saas", path: "saas"
+
+# Hosted transactional email (magic codes, approval notices) via SES. aws-sdk-rails
+# no longer ships an ActionMailer delivery method; this gem provides it.
+gem "aws-actionmailer-ses"

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -84,6 +84,10 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    aws-actionmailer-ses (1.2.0)
+      actionmailer (>= 7.1.0)
+      aws-sdk-ses (~> 1, >= 1.50.0)
+      aws-sdk-sesv2 (~> 1, >= 1.34.0)
     aws-eventstream (1.4.0)
     aws-partitions (1.1269.0)
     aws-sdk-core (3.254.0)
@@ -97,6 +101,12 @@ GEM
     aws-sdk-rails (5.1.0)
       aws-sdk-core (~> 3)
       railties (>= 7.1.0)
+    aws-sdk-ses (1.102.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sesv2 (1.103.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-sns (1.118.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
@@ -429,6 +439,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aws-actionmailer-ses
   aws-sdk-rails
   aws-sdk-sns
   bootsnap
@@ -476,10 +487,13 @@ CHECKSUMS
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  aws-actionmailer-ses (1.2.0) sha256=e01ccfcc5bf1449abb91bb8b15e7945e97310144c7f67fee8d9b76de2e89107f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
   aws-partitions (1.1269.0) sha256=80beca6c8a35ddfc11b0b529424ea6167ace3da92cd7368847ce694679dedea5
   aws-sdk-core (3.254.0) sha256=ee3e3220b8468a3c9e59daba18e6ec897bf5c7ce8adcc0670cfa2f1f092112fe
   aws-sdk-rails (5.1.0) sha256=8cffd3b60142e12a6747c91a7a609f668276b1082fc0c10810d5da3d14b13189
+  aws-sdk-ses (1.102.0) sha256=02bca66d12b856c37fce614f0f2ed68198af1ae938f41e08c53afac3bda2618f
+  aws-sdk-sesv2 (1.103.0) sha256=d371480f8092092ac760d306385b0f9e2bc6d3866c53bf6446c373dfdf088476
   aws-sdk-sns (1.118.0) sha256=46786eb1a27f8031163572043ed750cd292a1ca408527c5589ba5ecd43a0d2b9
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Authentication
+  include SetCurrentAccount
   include Pagy::Method
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.

--- a/app/controllers/concerns/set_current_account.rb
+++ b/app/controllers/concerns/set_current_account.rb
@@ -1,0 +1,17 @@
+module SetCurrentAccount
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_current_account
+  end
+
+  private
+
+  # OSS resolves to the instance account. Runs independently of the
+  # Authentication concern, whose early return (unconfigured HTTP auth) would
+  # otherwise skip it. The hosted engine overrides this to resolve the account
+  # from the signed-in user's membership.
+  def set_current_account
+    Current.account = Account.instance
+  end
+end

--- a/app/controllers/concerns/source_scoped.rb
+++ b/app/controllers/concerns/source_scoped.rb
@@ -8,6 +8,6 @@ module SourceScoped
   private
 
   def set_source
-    @source = Source.find(params[:source_id])
+    @source = Current.account.sources.find(params[:source_id])
   end
 end

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -2,7 +2,7 @@ class SourcesController < ApplicationController
   before_action :set_source, only: %i[show edit update destroy]
 
   def index
-    @sources = Source.alphabetically
+    @sources = Current.account.sources.alphabetically
     @source_stats = source_index_stats(@sources)
   end
 
@@ -25,11 +25,11 @@ class SourcesController < ApplicationController
   end
 
   def new
-    @source = Source.new(color: Source.next_available_color)
+    @source = Current.account.sources.new(color: Source.next_available_color)
   end
 
   def create
-    @source = Source.new(source_params)
+    @source = Current.account.sources.new(source_params)
 
     if @source.save
       redirect_to @source, notice: "Source created successfully."
@@ -57,7 +57,7 @@ class SourcesController < ApplicationController
   private
 
   def set_source
-    @source = Source.find(params[:id])
+    @source = Current.account.sources.find(params[:id])
   end
 
   def source_params

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -35,6 +35,10 @@ class WebhooksController < ApplicationController
 
   def set_source
     @source = Source.find_by!(token: params[:source_token])
+    # Ingest kill switch: un-approving an account (nulling approved_at) stops
+    # its sources accepting webhooks. In OSS the instance account is always
+    # approved, so this is a no-op there.
+    head :not_found unless @source.account.approved?
   rescue ActiveRecord::RecordNotFound
     head :not_found
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,24 @@
+class Account < ApplicationRecord
+  has_many :memberships, dependent: :destroy
+  has_many :users, through: :memberships
+  has_many :sources, dependent: :destroy
+
+  # The self-hosted singleton: every OSS install lives inside one instance
+  # account that owns all data. Created lazily so fresh schema-loaded installs
+  # (which never run migration bodies) still get it. `approved?` is always true
+  # for it, so the hosted approval gate never applies to self-hosting.
+  def self.instance
+    Current.instance_account ||= find_or_create_by!(instance: true) do |account|
+      account.name = "Sessy"
+      account.approved_at = Time.current
+    end
+  end
+
+  def approved?
+    approved_at.present?
+  end
+
+  def approve!
+    update!(approved_at: Time.current)
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,7 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :account
+  attribute :user, :session
+  # Per-request memo for the lazily-resolved instance account, so OSS mode
+  # doesn't hit the database on every Account.instance call.
+  attribute :instance_account
+end

--- a/app/models/magic_link.rb
+++ b/app/models/magic_link.rb
@@ -1,0 +1,44 @@
+class MagicLink < ApplicationRecord
+  CODE_LENGTH = 6
+  EXPIRATION_TIME = 15.minutes
+
+  belongs_to :user
+
+  enum :purpose, %w[ sign_in sign_up ], prefix: :for, default: :sign_in
+
+  scope :active, -> { where(expires_at: Time.current...) }
+  scope :stale, -> { where(expires_at: ..Time.current) }
+
+  before_validation :generate_code, on: :create
+  before_validation :set_expiration, on: :create
+
+  validates :code, uniqueness: true, presence: true
+
+  class << self
+    def consume(code)
+      active.find_by(code: Code.sanitize(code))&.consume
+    end
+
+    def cleanup
+      stale.delete_all
+    end
+  end
+
+  def consume
+    destroy
+    self
+  end
+
+  private
+
+  def generate_code
+    self.code ||= loop do
+      candidate = Code.generate(CODE_LENGTH)
+      break candidate unless self.class.exists?(code: candidate)
+    end
+  end
+
+  def set_expiration
+    self.expires_at ||= EXPIRATION_TIME.from_now
+  end
+end

--- a/app/models/magic_link.rb
+++ b/app/models/magic_link.rb
@@ -19,6 +19,15 @@ class MagicLink < ApplicationRecord
       active.find_by(code: Code.sanitize(code))&.consume
     end
 
+    # Verifies the browser-bound email before consuming, so a code submitted
+    # from the wrong browser is rejected without being destroyed (no burn-DoS).
+    def authenticate(code, email:)
+      link = active.find_by(code: Code.sanitize(code))
+      return unless link && ActiveSupport::SecurityUtils.secure_compare(email.to_s, link.user.email_address)
+
+      link.consume
+    end
+
     def cleanup
       stale.delete_all
     end

--- a/app/models/magic_link/code.rb
+++ b/app/models/magic_link/code.rb
@@ -1,0 +1,35 @@
+module MagicLink::Code
+  # Crockford-style base32: excludes I, L, O, U so codes stay unambiguous when
+  # read aloud or typed. The substitutions below fold the excluded letters onto
+  # their look-alike digits.
+  ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ".chars.freeze
+  CODE_SUBSTITUTIONS = { "O" => "0", "I" => "1", "L" => "1" }.freeze
+
+  class << self
+    def generate(length)
+      Array.new(length) { ALPHABET.sample(random: SecureRandom) }.join
+    end
+
+    def sanitize(code)
+      if code.present?
+        normalize_code(code)
+          .then { apply_substitutions(it) }
+          .then { remove_invalid_characters(it) }
+      end
+    end
+
+    private
+
+    def normalize_code(code)
+      code.to_s.upcase
+    end
+
+    def apply_substitutions(code)
+      CODE_SUBSTITUTIONS.reduce(code) { |result, (from, to)| result.gsub(from, to) }
+    end
+
+    def remove_invalid_characters(code)
+      code.gsub(/[^#{ALPHABET.join}]/, "")
+    end
+  end
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,6 @@
+class Membership < ApplicationRecord
+  belongs_to :account
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :account_id }
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,3 @@
+class Session < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,3 +1,16 @@
 class Session < ApplicationRecord
   belongs_to :user
+
+  # Sessions expire after this much inactivity; activity slides the window.
+  # updated_at doubles as last-active-at (a Session is only ever touched on use).
+  INACTIVITY_LIMIT = 30.days
+
+  def expired?
+    updated_at < INACTIVITY_LIMIT.ago
+  end
+
+  # Extend the idle window, but at most once a day to avoid a write per request.
+  def touch_if_stale
+    touch if updated_at < 1.day.ago
+  end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -2,6 +2,7 @@ class Source < ApplicationRecord
   include Colors
   include RetentionPolicy
 
+  belongs_to :account, default: -> { Account.instance }
   has_many :messages, dependent: :destroy
   has_many :events
 

--- a/app/models/source/account_backfill.rb
+++ b/app/models/source/account_backfill.rb
@@ -1,0 +1,8 @@
+# Assigns every account-less source to the instance account. Extracted from the
+# migration so the backfill logic is unit-testable against legacy-state rows.
+module Source::AccountBackfill
+  def self.run
+    account = Account.instance
+    Source.where(account_id: nil).update_all(account_id: account.id)
+  end
+end

--- a/app/models/source/retention_policy.rb
+++ b/app/models/source/retention_policy.rb
@@ -4,13 +4,25 @@ module Source::RetentionPolicy
   included do
     validates :retention_days, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
 
-    scope :with_retention_policy, -> { where.not(retention_days: nil) }
+    # Reaches sources with a per-source override AND sources relying on their
+    # account's default. The old per-source-only scope silently skipped the
+    # account-default case, so the daily job never enforced it.
+    scope :with_retention_policy, -> {
+      left_joins(:account)
+        .where("sources.retention_days IS NOT NULL OR accounts.retention_days IS NOT NULL")
+    }
+  end
+
+  # Per source first, then the owning account. nil means keep forever.
+  def effective_retention_days
+    retention_days || account&.retention_days
   end
 
   def delete_expired_data
-    return 0 unless retention_days
+    days = effective_retention_days
+    return 0 unless days
 
-    expired_messages = messages.where(sent_at: ..retention_days.days.ago)
+    expired_messages = messages.where(sent_at: ..days.days.ago)
     return 0 unless expired_messages.exists?
 
     Event.where(message_id: expired_messages.select(:id)).delete_all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,16 @@
+class User < ApplicationRecord
+  has_many :memberships, dependent: :destroy
+  has_many :accounts, through: :memberships
+  has_many :sessions, dependent: :destroy
+  has_many :magic_links, dependent: :destroy
+
+  normalizes :email_address, with: ->(e) { e.strip.downcase }
+
+  validates :email_address, presence: true, uniqueness: true
+
+  # Core only mints the record; the hosted engine owns delivery (its controllers
+  # send the code mailer). OSS never sends email.
+  def mint_magic_link(purpose: :sign_in)
+    magic_links.create!(purpose: purpose)
+  end
+end

--- a/bin/bundle-drift
+++ b/bin/bundle-drift
@@ -13,7 +13,7 @@ def versions(lockfile)
   Bundler::LockfileParser.new(File.read(lockfile)).specs.to_h { |spec| [ spec.name, spec.version.to_s ] }
 end
 
-SAAS_ONLY_GEMS = %w[ sessy-saas ]
+SAAS_ONLY_GEMS = %w[ sessy-saas aws-actionmailer-ses aws-sdk-ses aws-sdk-sesv2 ]
 
 oss = versions("Gemfile.lock")
 saas = versions("Gemfile.saas.lock")

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc, :code
 ]

--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,8 +1,20 @@
 Rails.application.config.after_initialize do
-  username = ENV.fetch("MISSION_CONTROL_USERNAME") { ENV["HTTP_AUTH_USERNAME"] }
-  password = ENV.fetch("MISSION_CONTROL_PASSWORD") { ENV["HTTP_AUTH_PASSWORD"] }
+  if Sessy.saas?
+    # Hosted mode never falls back to the retiring HTTP_AUTH_* chain and never
+    # falls open: with no MISSION_CONTROL_* credentials configured, /jobs is
+    # locked behind unguessable credentials rather than left unauthenticated.
+    username = ENV["MISSION_CONTROL_USERNAME"]
+    password = ENV["MISSION_CONTROL_PASSWORD"]
 
-  MissionControl::Jobs.http_basic_auth_enabled = username.present? && password.present?
-  MissionControl::Jobs.http_basic_auth_user = username
-  MissionControl::Jobs.http_basic_auth_password = password
+    MissionControl::Jobs.http_basic_auth_enabled = true
+    MissionControl::Jobs.http_basic_auth_user = username.presence || SecureRandom.hex(32)
+    MissionControl::Jobs.http_basic_auth_password = password.presence || SecureRandom.hex(32)
+  else
+    username = ENV.fetch("MISSION_CONTROL_USERNAME") { ENV["HTTP_AUTH_USERNAME"] }
+    password = ENV.fetch("MISSION_CONTROL_PASSWORD") { ENV["HTTP_AUTH_PASSWORD"] }
+
+    MissionControl::Jobs.http_basic_auth_enabled = username.present? && password.present?
+    MissionControl::Jobs.http_basic_auth_user = username
+    MissionControl::Jobs.http_basic_auth_password = password
+  end
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -17,3 +17,7 @@ production:
   delete_expired_data:
     class: DeleteExpiredDataJob
     schedule: every day at 4am
+
+  magic_link_cleanup:
+    command: "MagicLink.cleanup"
+    schedule: every day at 3am

--- a/db/migrate/20260718120000_create_accounts.rb
+++ b/db/migrate/20260718120000_create_accounts.rb
@@ -1,0 +1,14 @@
+class CreateAccounts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :accounts do |t|
+      t.string :name
+      t.datetime :approved_at
+      t.integer :retention_days
+      t.boolean :instance, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :accounts, :instance, unique: true, where: "instance"
+  end
+end

--- a/db/migrate/20260718120100_add_account_to_sources.rb
+++ b/db/migrate/20260718120100_add_account_to_sources.rb
@@ -1,0 +1,16 @@
+class AddAccountToSources < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :sources, :account, foreign_key: true
+
+    # Upgraders run migrations, so the instance account and backfill happen here.
+    # Fresh installs load the schema and never execute this body; Account.instance
+    # lazily creates the singleton at runtime instead.
+    Source::AccountBackfill.run
+
+    change_column_null :sources, :account_id, false
+  end
+
+  def down
+    remove_reference :sources, :account, foreign_key: true
+  end
+end

--- a/db/migrate/20260718120200_create_users.rb
+++ b/db/migrate/20260718120200_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :email_address, null: false
+
+      t.timestamps
+    end
+
+    add_index :users, :email_address, unique: true
+  end
+end

--- a/db/migrate/20260718120300_create_memberships.rb
+++ b/db/migrate/20260718120300_create_memberships.rb
@@ -1,0 +1,13 @@
+class CreateMemberships < ActiveRecord::Migration[8.1]
+  def change
+    create_table :memberships do |t|
+      t.references :account, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :role, null: false, default: "owner"
+
+      t.timestamps
+    end
+
+    add_index :memberships, [ :account_id, :user_id ], unique: true
+  end
+end

--- a/db/migrate/20260718120400_create_sessions.rb
+++ b/db/migrate/20260718120400_create_sessions.rb
@@ -1,0 +1,11 @@
+class CreateSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :ip_address
+      t.string :user_agent
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260718120500_create_magic_links.rb
+++ b/db/migrate/20260718120500_create_magic_links.rb
@@ -1,0 +1,14 @@
+class CreateMagicLinks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :magic_links do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :code, null: false
+      t.datetime :expires_at, null: false
+      t.integer :purpose, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :magic_links, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_17_160445) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_18_120500) do
+  create_table "accounts", force: :cascade do |t|
+    t.datetime "approved_at"
+    t.datetime "created_at", null: false
+    t.boolean "instance", default: false, null: false
+    t.string "name"
+    t.integer "retention_days"
+    t.datetime "updated_at", null: false
+    t.index ["instance"], name: "index_accounts_on_instance", unique: true, where: "instance"
+  end
+
   create_table "events", force: :cascade do |t|
     t.string "bounce_type"
     t.datetime "created_at", null: false
@@ -36,6 +46,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_160445) do
     t.index ["webhook_id"], name: "index_events_on_webhook_id"
   end
 
+  create_table "magic_links", force: :cascade do |t|
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.integer "purpose", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["code"], name: "index_magic_links_on_code", unique: true
+    t.index ["user_id"], name: "index_magic_links_on_user_id"
+  end
+
+  create_table "memberships", force: :cascade do |t|
+    t.integer "account_id", null: false
+    t.datetime "created_at", null: false
+    t.string "role", default: "owner", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["account_id", "user_id"], name: "index_memberships_on_account_id_and_user_id", unique: true
+    t.index ["account_id"], name: "index_memberships_on_account_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
   create_table "messages", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "events_count", default: 0, null: false
@@ -52,7 +84,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_160445) do
     t.index ["source_id"], name: "index_messages_on_source_id"
   end
 
+  create_table "sessions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "ip_address"
+    t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
   create_table "sources", force: :cascade do |t|
+    t.integer "account_id", null: false
     t.string "color", default: "blue"
     t.datetime "created_at", null: false
     t.integer "messages_count", default: 0, null: false
@@ -60,7 +102,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_160445) do
     t.integer "retention_days"
     t.string "token", null: false
     t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_sources_on_account_id"
     t.index ["token"], name: "index_sources_on_token", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email_address", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
   create_table "webhooks", force: :cascade do |t|
@@ -78,5 +128,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_160445) do
   add_foreign_key "events", "messages"
   add_foreign_key "events", "sources"
   add_foreign_key "events", "webhooks"
+  add_foreign_key "magic_links", "users"
+  add_foreign_key "memberships", "accounts"
+  add_foreign_key "memberships", "users"
   add_foreign_key "messages", "sources"
+  add_foreign_key "sessions", "users"
+  add_foreign_key "sources", "accounts"
 end

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -152,3 +152,18 @@ builder:
   args:
     BUNDLE_GEMFILE: Gemfile.saas
 ```
+
+### Hosted environment variables
+
+The hosted edition adds multi-tenant signup, magic-code auth, and transactional email. Set these on the hosted deploy (via Kamal secrets / `env.clear`):
+
+| Variable | Purpose |
+| --- | --- |
+| `MAILER_FROM_ADDRESS` | From address for magic-code and approval emails (e.g. `Sessy <hello@sessy.do>`). |
+| `APP_HOST` | Public host for links in emails (e.g. `app.sessy.do`). |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | SES sending credentials (or use a host IAM role). Delivery uses SESv2 in production. |
+| `MISSION_CONTROL_USERNAME` / `MISSION_CONTROL_PASSWORD` | Operator credentials for `/jobs`. In hosted mode `/jobs` is locked with unguessable credentials if these are unset — set them before you need the dashboard. |
+
+Magic codes and approval emails require a **verified SES sending identity** for `MAILER_FROM_ADDRESS`. In development the sign-in code is shown on the code-entry page (and an `X-Magic-Code` header), so no mail setup is needed locally.
+
+Retire `HTTP_AUTH_USERNAME` / `HTTP_AUTH_PASSWORD` from the hosted env only after cutover — magic-code auth replaces them, and the hosted app ignores them.

--- a/docs/hosted-launch-runbook.md
+++ b/docs/hosted-launch-runbook.md
@@ -1,0 +1,44 @@
+# Hosted launch runbook
+
+Steps to turn app.sessy.do into the multi-tenant hosted edition. Maintainer-run; not part of the PR.
+
+## Pre-deploy
+
+1. **Verify the SES sending identity** for `MAILER_FROM_ADDRESS` (e.g. `hello@sessy.do`) and send a test email — magic codes and approval notices can't ship without it.
+2. **Store SES sending credentials** in Kamal secrets (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) or attach a host IAM role.
+3. **Set `MISSION_CONTROL_USERNAME` / `MISSION_CONTROL_PASSWORD`** on the hosted env. In hosted mode `/jobs` is locked with unguessable credentials until these are set.
+4. **Set `APP_HOST=app.sessy.do`** so email links resolve.
+5. Confirm `config/deploy.saas.yml` carries `builder.args.BUNDLE_GEMFILE: Gemfile.saas`.
+6. **Rehearse the migration** against a copy of the production database (`bin/rails db:migrate` on the copy) and confirm every source ends up owned by the instance account with history intact.
+
+## Deploy
+
+7. `kamal deploy -c config/deploy.saas.yml`. The container runs the migration on boot: existing sources land in the auto-created **instance account**, already approved with unlimited retention, so **webhook ingest never pauses**.
+   - Do not create sources during the deploy window — the old container can't satisfy the new `NOT NULL account_id`. Ingest (events/messages) is unaffected.
+
+## Claim
+
+8. `bin/rails "saas:claim[you@example.com]"` — attaches your user + owner membership to the instance account (which owns all migrated data). Idempotent.
+9. Sign in at `app.sessy.do` with the magic code, confirm your sources and history are present and webhook URLs still work.
+
+## Finalize
+
+10. **Retire `HTTP_AUTH_USERNAME` / `HTTP_AUTH_PASSWORD`** from the hosted env last — magic-code auth has replaced them and the hosted app ignores them.
+
+## Approving new signups
+
+New accounts land pending. Approve from the console:
+
+```ruby
+Account.find_by!(name: "Casey's Sessy").approve!   # sends the approval email
+```
+
+## Abuse response
+
+Approval is otherwise permanent; to cut off an abusive account:
+
+```ruby
+account = Account.find(...)
+account.update!(approved_at: nil)   # re-gates the UI and stops webhook ingest (404s)
+account.sources.destroy_all         # escalation: drop their sources entirely
+```

--- a/docs/plans/2026-07-18-001-feat-hosted-sessy-launch-plan.md
+++ b/docs/plans/2026-07-18-001-feat-hosted-sessy-launch-plan.md
@@ -1,0 +1,355 @@
+---
+title: Hosted Sessy Launch - Plan
+type: feat
+date: 2026-07-18
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+deepened: 2026-07-18
+---
+
+# Hosted Sessy Launch - Plan
+
+## Goal Capsule
+
+- **Objective:** app.sessy.do becomes a multi-tenant product people can sign up for with magic-code auth, gated by manual approval, with 30-day default retention — while self-hosted installs remain exactly the product they are today.
+- **Product authority:** this Product Contract. The saas engine boundary (docs/plans/2026-07-17-001-feat-saas-engine-foundation-plan.md, shipped in PR #154) is the architectural substrate; basecamp/fizzy's auth is the implementation reference.
+- **Stop conditions:** surface instead of guessing if implementation would require weakening an OSS invariant (R10-R12), an engine-owned migration on a core table, or a behavior AE1 can't pass with.
+- **Open blockers:** none. Operational prerequisite outside the repo: a verified SES sending identity for hosted transactional email (see Dependencies).
+- **Execution profile:** feature branch (`marc/` prefix); commit/push/PR only with explicit user approval.
+
+---
+
+## Product Contract
+
+*Preservation note: changed from the requirements-only version — R13 amended (migration pins unlimited retention, approval atomic), R15-R16 added (abuse and operational guards), F1/F2 merged-form and typed-code clarifications, AE4 sharpened, AE7-AE8 added. All from flow analysis; no scope change.*
+
+### Summary
+
+Add users, accounts, and memberships to Sessy's core with a single-code-path tenancy design: every install has accounts, but a self-hosted install lives invisibly inside one auto-created instance account with today's UX untouched. The hosted edition activates magic-code signup and login on top, gated by manual account approval, defaulting to 30-day retention. Free early access; no billing.
+
+### Actors
+
+- A1. Marc — operator of the hosted instance; approves accounts and grants retention overrides via console.
+- A2. Hosted user — friend or indie dev who signs up at app.sessy.do to watch their SES activity.
+- A3. Self-hoster — runs Sessy from the public image or repo; must notice no change.
+
+### Requirements
+
+**Hosted identity and access**
+
+- R1. A visitor can sign up at app.sessy.do with just an email address; completing signup creates a user, an account, and an owner membership.
+- R2. Sign-in is by emailed one-time code only; hosted mode has no passwords and no shared HTTP Basic credential.
+- R3. The data model supports multiple users per account with roles (owner-only at launch); adding a teammate later must require no schema change.
+- R4. One account per user at launch; no account switching UI.
+
+**Approval gate**
+
+- R5. New accounts are pending until Marc approves them (timestamp flag, set via console).
+- R6. A pending account can sign in but only sees a pending page: no source creation, no webhook ingest, no data.
+- R7. On approval, the user receives an email; there is no rejection flow — unapproved accounts stay pending.
+
+**Retention**
+
+- R8. Hosted accounts default to 30-day retention, resolved per source first, then account; retention enforcement must reach sources that rely on the account default.
+- R9. Marc can change an account's retention (raise, lower, or unlimited) via console; self-hosted retention behavior is unchanged (unlimited unless a source sets it).
+
+**Self-hosted invariants**
+
+- R10. A self-hosted install has no login, no signup, no email-sending requirement; optional HTTP Basic works exactly as today.
+- R11. Existing self-hosted installs upgrade with a plain migration: their data lands in an auto-created instance account with no operator action and no behavior change.
+- R12. Email features are never a setup prerequisite for self-hosting; any future OSS email capability is gradual opt-in.
+
+**Abuse and operational guards**
+
+- R15. Auth endpoints are rate-limited per requester and per target email address (email submission and code verification), and responses for unknown emails are indistinguishable from known ones.
+- R16. The `/jobs` dashboard stays behind its own operator credentials, independent of hosted user sessions.
+
+**Migration and launch**
+
+- R13. The existing app.sessy.do data migrates into Marc's account as tenant #1: history preserved, webhook URLs unchanged, retention pinned unlimited, approval set atomically with the data reassignment so ingest never pauses.
+- R14. All hosted-only behavior (signup, login, approval, retention defaults) activates through the saas engine; the OSS test suite proves R10-R11.
+
+### Key Flows
+
+- F1. Signup: visitor enters email on the single email form → emailed code → types code in the same browser → names themselves → account created (pending) → pending page → Marc approves in console → approval email → user creates first source.
+- F2. Sign-in: existing user enters email on the same form → emailed code → types code → session.
+- F3. Self-hosted install: unchanged from today (`docker run ...` → working instance, optional HTTP Basic).
+- F4. Launch migration: deploy → migration creates the instance account (approved, unlimited retention) owning existing data → Marc attaches his user and owner membership via a console claim operation.
+
+### Acceptance Examples
+
+- AE1. Fresh OSS install: no login screen, no email config prompted; setting `HTTP_AUTH_*` env vars gates the UI exactly as before.
+- AE2. New hosted signup: sees pending page; cannot create a source; a webhook POST to a guessed token ingests nothing.
+- AE3. Marc runs the console approval; the user gets an email and can then create sources and receive events.
+- AE4. A code is single-use, expires in 15 minutes, and only works in the browser that requested it; hosted responses never accept the old shared Basic credential.
+- AE5. A hosted account's events older than 30 days are deleted by the daily job even when no source sets per-source retention, unless Marc changed that account's retention.
+- AE6. After launch migration, Marc's existing sources (BetaList, WIP) live in his account with full history and working webhook URLs.
+- AE7. Submitting an unknown email produces the same response and page as a known one.
+- AE8. A signed-in, approved hosted user without operator credentials cannot open `/jobs`.
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- Billing and plans (Fizzy's removed Stripe implementation is the catalogued reference).
+- Teams: invitations, roles beyond owner, account switching — schema supports them; no UI or flows.
+- Admin UI: approvals and overrides are console-driven at launch.
+- OSS "accounts mode" opt-in toggle — future option, zero known demand.
+- Alerts, weekly summaries, MCP, marketing site.
+- Session management UI (list/revoke devices); console can destroy session rows if ever needed.
+
+**Outside this product's identity**
+
+- Passwords, in any mode.
+- Mandatory login or email configuration for self-hosters — frictionless install is the OSS identity.
+
+### Key Decisions
+
+- Single code path via instance account: accounts exist in both modes; OSS auto-creates one invisible account owning everything. Chosen over dual-path controllers (drift risk) and engine-injected scoping (brittle).
+- Emailed one-time code (typed, browser-bound) is the only hosted door — Fizzy's exact scheme, chosen over a clickable link for its anti-phishing/replay properties and because the reference implementation is battle-tested. Cross-device works by reading the code on one device and typing on another.
+- Approval is a timestamp, not a state machine; pending forever is the only non-approved state.
+- Success signal is informal: a handful of friends/indie devs with webhooks actively flowing.
+
+### Dependencies
+
+- A verified SES sending identity/domain for hosted transactional email (magic codes, approval notices) — operational setup outside the repo, required before launch.
+- Distinct `MISSION_CONTROL_USERNAME`/`MISSION_CONTROL_PASSWORD` set on the hosted deploy before the shared `HTTP_AUTH_*` credentials are retired (R16).
+
+### Sources
+
+- Verified against the repo 2026-07-18: no user/account/session models exist (`db/schema.rb` has 4 tables); auth is the optional HTTP Basic concern (`app/controllers/concerns/authentication.rb`) skipped by `WebhooksController`; per-source nullable `retention_days` with a daily `DeleteExpiredDataJob` (`config/recurring.yml`); webhook ingest is per-source tokenized and SNS-verified; the app sends no email today; no tenancy concepts anywhere.
+- basecamp/fizzy auth studied in depth 2026-07-18 (clone at 595ebf5): `app/models/magic_link.rb` (+ `magic_link/code.rb`), `app/controllers/concerns/authentication.rb` (+ `authentication/via_magic_link.rb`), `app/controllers/sessions_controller.rb`, `app/controllers/sessions/magic_links_controller.rb`, `app/models/signup.rb`, `app/models/account/multi_tenantable.rb`, `app/models/current.rb`. Explicitly not copied: passkeys, session QR transfer, Queenbee tenant ids, the `AccountSlug` URL-prefix middleware, MySQL/UUID PKs.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **Copy Fizzy's auth machinery, adapted, not reinvented.** `MagicLink` (6-char base32 code, unique index, 15-minute expiry, destroy-on-consume, recurring cleanup), `MagicLink::Code.sanitize` (upcase, O→0/I→1/L→1), the pending-authentication signed cookie that binds a code to the requesting browser, the fake-magic-link response for unknown emails (anti-enumeration), Rails 8 `rate_limit` (10/3min on email submission, 10/15min on code verification), DB-backed `Session` rows referenced by a signed permanent cookie, and the development-mode code display (flash + response header, with the leak-guard after_action). Multiple outstanding codes per user within the expiry window are allowed, as in Fizzy.
+- **Naming: Sessy uses `User` / `Membership` / `Account` where Fizzy uses `Identity` / `User` / `Account`.** Same three-table structure (global credentials record; per-account role record with unique `[account_id, user_id]`; tenant). Conventional names fit a repo with no legacy vocabulary; the plan's Fizzy file references map Identity→User, User→Membership.
+- **Placement: schema and models in core, entire auth surface in the engine.** Core gains the tables (accounts, users, sessions, magic_links, memberships, `sources.account_id`) and models — dormant in OSS, no routes, no UI. The engine adds all auth/signup/pending routes via `app.routes.append`, controllers, views, and mailers, and overrides `ApplicationController#authenticate` via `config.to_prepare` (keeping the callback name so `WebhooksController`'s `skip_before_action :authenticate` is untouched). OSS keeps the existing HTTP Basic concern as-is.
+- **Session-resolved current account; no URL-prefix middleware.** `Current.account` resolves from the session's user → sole membership (hosted) or the instance account (OSS). Fizzy's `AccountSlug`/`script_name` machinery buys account-addressed URLs we don't need at one-account-per-user; skipping it removes a whole middleware layer. Revisit only when account switching becomes real.
+- **Instance account is a lazy runtime singleton; the migration only serves upgraders.** `Account.instance` = memoized `find_or_create_by` on a dedicated flag column (the deterministic discriminator OSS resolution, fixtures, and the U8 claim task all share) — fresh installs run `db:prepare`, which schema-loads and never executes migration bodies, so a migration-created account would not exist on a fresh Docker install (review-verified against `bin/docker-entrypoint` and `bin/setup`). The upgrade migration still creates the instance account inline and backfills `sources.account_id` before NOT NULL (upgraders do run migrations; backfill is extracted into a callable the migration invokes so it stays unit-testable). `Current.account` assignment runs as its own before_action, independent of the HTTP-auth concern's early return.
+- **Retention: one nullable `accounts.retention_days` column.** Hosted signup sets 30 on account creation (engine); nil means unlimited (OSS instance account, and Marc's migrated account). Effective retention = `source.retention_days || account.retention_days`. `DeleteExpiredDataJob`/`Source.with_retention_policy` is redesigned to enumerate both per-source overrides and sources whose account has a default — today's `where.not(retention_days: nil)` cannot see the account-default case (flow-analysis critical gap). Console override is just writing `account.retention_days`.
+- **`/jobs` keeps its own credential gate.** `config/initializers/mission_control.rb` already reads `MISSION_CONTROL_*` with `HTTP_AUTH_*` fallback; hosted sets distinct `MISSION_CONTROL_*` values. Guard added: in SaaS mode with no Mission Control credentials configured, the mount refuses access rather than falling open once `HTTP_AUTH_*` is retired.
+- **Launch migration is structural, plus a one-line ingest kill switch.** The upgrade migration on the hosted DB lands existing sources in the instance account, already approved with nil retention, so ingest never pauses. Pending accounts can't create sources (structural block), and `WebhooksController` additionally checks `source.account.approved?` — one cheap line that makes nulling `approved_at` a real abuse kill switch (AE2 holds in both directions; the review's revocation gap). Marc's claim is a console operation attaching his User + owner Membership to the instance account.
+- **Hosted email via `aws-actionmailer-ses` (`:ses_v2`).** Review-verified: aws-sdk-rails 5.x does *not* ship a delivery method — the SES ActionMailer integration lives in the separate `aws-actionmailer-ses` gem. It goes in `Gemfile.saas` only (core bundle untouched, R12), with `bin/bundle-drift`'s `SAAS_ONLY_GEMS` allowlist extended for it and its transitive deps. Delivery method `:ses_v2` (the current API). SES sending credentials reach the deploy the same way other hosted secrets do: Kamal secrets from 1Password (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` or host IAM role — named in the runbook). `MAILER_FROM_ADDRESS` env, hosted `default_url_options`. OSS delivery config stays untouched.
+- **Core mints, engine sends — everywhere.** No core model references a mailer: `User#send_magic_link` and `Account#approve!` in core only create records / set timestamps; the engine decorates them (`config.to_prepare` module prepend) to enqueue the code and approval emails. This one discipline resolves placement for both mail paths (review-flagged contradiction). The approval email is a plain notification directing the user to the normal sign-in form — never an embedded access link. Both new cookies (session, pending-authentication) are `httponly`, `secure` outside dev, `same_site: :lax`. The code parameter is added to `filter_parameters` (the existing `:otp` filter would not catch Fizzy's `code` param name). The dev-mode code display is gated on `Rails.env.development?` specifically, never `SESSY_MODE`, with Fizzy's leak-guard after_action. Table/model names keep Fizzy's `magic_links`/`MagicLink`; prose and UI say "code".
+
+### High-Level Technical Design
+
+Data model (new tables shaded by placement — all in core schema):
+
+```mermaid
+erDiagram
+    ACCOUNT ||--o{ MEMBERSHIP : has
+    USER ||--o{ MEMBERSHIP : has
+    USER ||--o{ SESSION : has
+    USER ||--o{ MAGIC_LINK : has
+    ACCOUNT ||--o{ SOURCE : owns
+    SOURCE ||--o{ MESSAGE : has
+    SOURCE ||--o{ EVENT : has
+    ACCOUNT {
+        string name
+        datetime approved_at
+        integer retention_days "nullable; nil = unlimited"
+    }
+    USER {
+        string email_address "unique"
+    }
+    MEMBERSHIP {
+        string role "owner"
+        index account_id_user_id "unique"
+    }
+    MAGIC_LINK {
+        string code "unique, 6-char base32"
+        datetime expires_at "15 min"
+        integer purpose "sign_in | sign_up"
+    }
+```
+
+Hosted sign-in/signup flow (merged entry; engine-owned):
+
+```mermaid
+sequenceDiagram
+    participant V as Visitor/User
+    participant S as Engine sessions controller
+    participant M as Mailer (SES)
+    participant C as Code verification
+    V->>S: submit email (rate limited 10/3min)
+    alt known email
+        S->>M: send code (purpose sign_in)
+    else unknown email
+        S->>M: send code (purpose sign_up, user created)
+    end
+    S-->>V: identical "check your email" page + pending-auth cookie
+    V->>C: type code (rate limited 10/15min)
+    C->>C: consume(code), secure-compare cookie email
+    alt user has no membership
+        C-->>V: name form -> create Account (pending) + owner Membership -> pending page
+    else user has a membership
+        C-->>V: session cookie -> dashboard (or pending page if unapproved)
+    end
+```
+
+Completion routing keys on **membership presence, not code purpose**: a User row is created at email submission, so an abandoned signup would otherwise strand that email forever on the sign-in branch with no account to resolve (review-verified shadow path). Any verified user with zero memberships lands on the name form.
+
+Mode resolution: OSS requests authenticate via the existing HTTP Basic concern and `Current.account` = the instance account; hosted requests authenticate via session cookie (engine override of `authenticate`) and `Current.account` = the session user's sole membership's account, with a pending-page gate before any tenant surface.
+
+### Risks and Mitigations
+
+- **Live-data migration on the hosted DB** — the U1 migration runs against production data at deploy. Mitigation: identical migration path is exercised by every OSS upgrade test on both adapters, ingest gating is structural (no pause window), and the runbook mandates a rehearsal against a DB copy before the real deploy (U8).
+- **Auth is easy to get subtly wrong** — replay, enumeration, throttling, session fixation. Mitigation: port Fizzy's battle-tested scheme mechanism-for-mechanism (destroy-on-consume, browser binding, fake-link responses, rate limits) rather than designing novel auth; AE4/AE7 encode the properties as tests.
+- **Retention sweep touching the wrong data** — the redesigned enumeration is the one place a query bug deletes tenant data. Mitigation: U6's resolution-matrix tests cover every branch including the both-nil no-op; Marc's account is nil-retention by migration, not convention.
+- **SES deliverability for auth email** — codes landing in spam block sign-in entirely. Mitigation: verified sending identity is a named launch gate; dev-mode code display keeps development unblocked; deliverability check is a runbook step.
+- **Approval bottleneck is Marc** — console-only approval means signups stall if unnoticed. Accepted at friends-and-indies scale; admin UI is explicitly deferred.
+
+---
+
+## Implementation Units
+
+### U1. Accounts table, instance account, and source ownership
+
+- **Goal:** Every install has accounts; existing installs upgrade invisibly (the OSS-invariant-critical unit).
+- **Requirements:** R11, R13 (shared migration), R14, AE1, AE6
+- **Dependencies:** none
+- **Files:** `db/migrate/*` (accounts; instance-account creation + `sources.account_id` backfill + NOT NULL), `app/models/account.rb`, `app/models/source.rb`, `app/models/current.rb`, `test/models/account_test.rb`, `test/fixtures/accounts.yml`, `test/fixtures/sources.yml`
+- **Approach:** Accounts: `name`, `approved_at`, `retention_days` (nil default), plus the instance-account flag column. `Account.instance` = memoized `find_or_create_by` on the flag — lazy at runtime, so fresh schema-loaded installs (`db:prepare` never runs migration bodies) self-heal; the migration creates it inline only for the upgrade backfill of `sources.account_id` (extracted into a callable the migration invokes, so the backfill logic is unit-testable) before NOT NULL. `Current` gains `account`; OSS resolution sets `Current.account = Account.instance` in its own before_action (not inside `authenticate`, whose unconfigured-HTTP-auth early return would skip it). `Account#approved?` = `approved_at.present?`. Fixtures gain a default (flagged) account; sources fixtures reference it.
+- **Patterns to follow:** Fizzy `app/models/current.rb` (attribute cascade); ONCE-style lazy first-run singleton; repo's nested-concern style.
+- **Test scenarios:**
+  - Covers AE6/R11: the extracted backfill callable, run against rows created without `account_id` (in-test legacy state), assigns every source to the instance account; account is approved with nil retention.
+  - Happy path: deleting the instance account row and calling `Account.instance` recreates it exactly once (lazy self-heal); concurrent-safe via find_or_create.
+  - Both adapters: suite green under SQLite and PostgreSQL (CI matrix already runs both).
+  - Edge: `Account#approved?` false when `approved_at` nil.
+- **Verification:** OSS suite green with zero behavior diff; `db/schema.rb` shows the new tables; manual OSS boot shows identical UI.
+
+### U2. Identity models: User, Membership, Session, MagicLink
+
+- **Goal:** The dormant identity layer — tables and models in core, no routes or UI.
+- **Requirements:** R1, R3, R15 (model half)
+- **Dependencies:** U1
+- **Files:** `db/migrate/*` (users, memberships, sessions, magic_links), `app/models/user.rb`, `app/models/membership.rb`, `app/models/session.rb`, `app/models/magic_link.rb`, `app/models/magic_link/code.rb`, `test/models/magic_link_test.rb`, `test/models/user_test.rb`, `test/fixtures/{users,memberships}.yml`
+- **Approach:** Port Fizzy's `MagicLink` + `Code` (generation retry loop, sanitize, `consume` destroy-on-use, `active` scope, purpose enum, `cleanup` for recurring), `Session` (user_id, ip, user_agent), `Membership` (role string default owner, unique `[account_id, user_id]`), `User` (unique email, normalized). Per the core-mints/engine-sends decision: core `User#mint_magic_link(purpose:)` only creates the record; the engine's controllers own delivery (U3's mailer). `MagicLink.cleanup` gets an unconditional entry in `config/recurring.yml`'s production block — the file is flat core config Solid Queue reads directly (no "SaaS block" exists or is needed); cleanup is a free no-op on the always-empty OSS table. The code parameter name is added to `config/initializers/filter_parameter_logging.rb`.
+- **Patterns to follow:** Fizzy `app/models/magic_link.rb`, `magic_link/code.rb`, `session.rb`; Identity→User, User→Membership mapping.
+- **Test scenarios:**
+  - Covers AE4 (model half): consumed code cannot be consumed again; expired code not consumable; `Code.sanitize` maps `O/I/L` and strips non-base32.
+  - Happy path: membership uniqueness on `[account_id, user_id]`; role defaults to owner.
+  - Edge: code generation retries on collision (unique index holds).
+- **Verification:** OSS suite green; models load in OSS with no routes referencing them (regression tests from U7 prove no surface).
+
+### U3. Engine auth surface: merged email form, code verification, sessions
+
+- **Goal:** Hosted sign-in works end to end: one email form, typed code, browser binding, session cookie, sign-out.
+- **Requirements:** R2, R15, F1, F2, AE4, AE7
+- **Dependencies:** U2
+- **Files:** `saas/config/routes.rb`, `saas/app/controllers/sessy/saas/sessions_controller.rb`, `saas/app/controllers/sessy/saas/sessions/codes_controller.rb`, `saas/app/controllers/concerns/sessy/saas/authentication.rb` (session auth + pending-auth cookie), `saas/app/mailers/sessy/saas/code_mailer.rb` (+ views), `saas/app/views/...` (email form, code form, check-your-email), `saas/lib/sessy/saas/engine.rb` (to_prepare override of `authenticate`), `saas/test/controllers/sessions_test.rb`
+- **Approach:** Port Fizzy's `SessionsController` + `Sessions::MagicLinksController` + `Authentication`/`ViaMagicLink` concerns: merged create (known email → sign-in code; unknown → create User + sign-up code; both render the identical page — fake-link behavior included), pending-authentication signed cookie bound to the code's email and expiry, `secure_compare` at verification, `rate_limit to: 10, within: 3.minutes` (email, per IP) plus a per-target-email throttle (a second `rate_limit` keyed on the submitted address — per-IP alone can't stop a victim's inbox being spammed or SES reputation burn), and `to: 10, within: 15.minutes` (code), signed permanent session cookie from `Session#signed_id`, sign-out destroys the row. Engine's `to_prepare` swaps `ApplicationController`'s `authenticate` to session auth in hosted mode (same callback name; webhook skip untouched); unauthenticated hosted requests redirect to the email form. Development code display: flash + `X-Magic-Link-Code` header with Fizzy's leak-guard after_action.
+- **Patterns to follow:** Fizzy `app/controllers/sessions_controller.rb`, `sessions/magic_links_controller.rb`, `concerns/authentication.rb`, `concerns/authentication/via_magic_link.rb`.
+- **Test scenarios (SaaS suite):**
+  - Covers F2/AE4: full sign-in round trip via the header-exposed code; code from a different browser (no pending cookie) rejected; second use of the code rejected.
+  - Covers AE7: unknown vs known email produce byte-identical response status/template.
+  - Error paths: expired code; garbage code; rate limit returns the friendly handler response (test env uses `:null_store`, so either stub `Rails.cache.increment` — Fizzy's own pattern — for handler wiring, or swap in a memory store to prove the thresholds).
+  - Covers AE4's Basic-inertness clause: with `HTTP_AUTH_*` set in ENV, a hosted request carrying the matching Basic Authorization header is redirected to sign-in and gets no session — pins the override regardless of method-resolution wiring, and covers the runbook window where the env vars still exist.
+  - Integration: signed-out user hitting a tenant page redirects to the email form; sign-out destroys the session row and cookie; both cookies carry httponly/secure/lax attributes.
+- **Test scenarios (OSS suite):** auth routes absent (404); `ApplicationController` still uses HTTP Basic concern (AE1 regression).
+- **Verification:** hosted dev boot: full sign-in flow in browser (screenshot); OSS boot unchanged.
+
+### U4. Signup completion, pending gate, approval
+
+- **Goal:** Signup creates a pending account; pending users are fully gated; console approval notifies and unlocks.
+- **Requirements:** R1, R4, R5, R6, R7, AE2, AE3
+- **Dependencies:** U3
+- **Files:** `saas/app/models/sessy/saas/signup.rb`, `saas/app/controllers/sessy/saas/signups/completions_controller.rb`, `saas/app/controllers/concerns/sessy/saas/approval_gate.rb`, `saas/app/views/...` (name form, pending page), `saas/app/mailers/sessy/saas/*` (code mailer, approval mailer), `app/models/account.rb` (`approve!`), `saas/test/controllers/signups_test.rb`, `saas/test/models/signup_test.rb`
+- **Approach:** Port Fizzy's `Signup` orchestrator shape (ActiveModel, contextual validations, transactional complete): after code verification, any user with zero memberships gets the name form (membership-presence routing, not purpose) → `Account` (pending, hosted default retention from U6) + owner `Membership` in one transaction. `ApprovalGate` concern hooks into `ApplicationController` (opt-out for every current and future hosted route, not opt-in per controller — review P1): approved-account check rendering the pending page, reading `approved_at` live per request. Core `Account#approve!` sets the timestamp only; the engine prepends the approval-email delivery (core-mints/engine-sends). The approval email is a notification pointing at the normal sign-in form. Console one-liner: `Account.find_by!(...).approve!`. Un-approval (nulling the timestamp) re-gates the UI and, with U5's webhook check, stops ingest.
+- **Patterns to follow:** Fizzy `app/models/signup.rb` (minus tenant/billing hooks), `signups/completions_controller.rb`.
+- **Test scenarios (SaaS suite):**
+  - Covers F1/AE2: completed signup → account pending → source creation blocked (controller-level), pending page rendered on every tenant route; sources index unreachable.
+  - Covers AE3: `approve!` flips access on the next request (no re-login needed) and enqueues the approval email.
+  - Edge: signup transaction rolls back cleanly on failure (no orphan account/membership); duplicate signup for an existing email routes to sign-in semantics, not a second account (R4).
+  - Integration: pending account has no sources, so any webhook POST 404s (structural ingest block).
+- **Verification:** full signup→pending→approve→create-source flow in hosted dev boot (screenshots of pending page and post-approval).
+
+### U5. Tenancy scoping and hosted account resolution
+
+- **Goal:** Every tenant query flows through `Current.account` in both modes; hosted resolves it from the session.
+- **Requirements:** R4, R10, R14, AE1
+- **Dependencies:** U1, U3
+- **Files:** `app/controllers/concerns/source_scoped.rb`, `app/controllers/sources_controller.rb`, `app/controllers/events_controller.rb`, `app/controllers/messages_controller.rb`, `app/models/current.rb`, `saas/app/controllers/concerns/sessy/saas/account_resolution.rb`, `test/integration/oss_mode_test.rb`, `saas/test/controllers/tenancy_test.rb`
+- **Approach:** Core controllers scope through `Current.account.sources` (and events/messages through their source's account) instead of unscoped `Source.find`. OSS: `Current.account = Account.instance`, set by a dedicated before_action independent of the HTTP-auth concern (whose early return would otherwise skip it). Hosted: engine concern resolves `Current.account` from the session user's sole membership. `WebhooksController` stays token-scoped and sessionless, but gains the one-line `source.account.approved?` check (ingest kill switch; 404 on unapproved).
+- **Patterns to follow:** Fizzy's explicit association scoping (`Current.user.boards...`), no default_scope; `belongs_to :account, default:` for new sources.
+- **Test scenarios:**
+  - Covers R4 tenant isolation (SaaS suite): user A cannot reach user B's source/events/messages by id (404, not 403 — no existence leak).
+  - OSS suite: all existing controller flows still resolve through the instance account with identical responses (AE1 regression).
+  - Integration: webhook POST for account A's source token ingests into account A regardless of any session.
+  - Covers AE2 both directions: a webhook POST to a source whose account has `approved_at` nulled returns 404 and ingests nothing.
+- **Verification:** both suites green; manual two-account isolation check in hosted dev boot.
+
+### U6. Retention defaults, resolution, and sweep redesign
+
+- **Goal:** 30-day hosted default that the daily job actually enforces; console-adjustable per account.
+- **Requirements:** R8, R9, AE5
+- **Dependencies:** U1, U4 (edits the signup orchestrator U4 creates)
+- **Files:** `app/models/source/retention_policy.rb`, `app/models/account.rb` (retention accessors), `app/jobs/delete_expired_data_job.rb`, `saas/app/models/sessy/saas/signup.rb` (default 30 on create), `test/models/source_retention_policy_test.rb`, `saas/test/models/retention_default_test.rb`
+- **Approach:** Effective retention = `source.retention_days || source.account.retention_days` (nil → keep forever). Redesign the sweep enumeration: replace `Source.with_retention_policy` (`where.not(retention_days: nil)`) with a query reaching sources that have either a per-source value or an account default (join/where-exists on accounts.retention_days) — the flow-analysis critical gap. Hosted signup sets `retention_days: 30` on the new account; OSS instance account stays nil. Console override = assigning `account.retention_days`.
+- **Patterns to follow:** existing `Source::RetentionPolicy` batch-delete shape; keep deletion batched as today.
+- **Test scenarios:**
+  - Covers AE5: source with nil retention in an account with 30 → 31-day-old events deleted, 29-day-old kept; per-source 7 overrides account 30 in both directions; nil/nil deletes nothing.
+  - Edge: account default added later applies to pre-existing sources on the next run.
+  - OSS regression: instance account nil → sweep touches nothing without per-source values (today's behavior).
+- **Verification:** job run in test covers all resolution branches; OSS suite green.
+
+### U7. Hosted email delivery and /jobs guard
+
+- **Goal:** Hosted mode can actually send the codes and approval emails; `/jobs` never falls open.
+- **Requirements:** R12, R16, AE8, Dependencies
+- **Dependencies:** U3 (code mailer), U4 (approval mailer)
+- **Files:** `Gemfile.saas` + `Gemfile.saas.lock` (add `aws-actionmailer-ses`), `bin/bundle-drift` (extend `SAAS_ONLY_GEMS`), `saas/lib/sessy/saas/engine.rb` (mailer config), `saas/config/` (delivery settings), `config/initializers/mission_control.rb`, `docs/docker-deployment.md` (hosted env vars), `saas/test/mailer_config_test.rb`, `test/integration/oss_mode_test.rb` (no-delivery regression)
+- **Approach:** Add `aws-actionmailer-ses` to `Gemfile.saas` (verified: aws-sdk-rails 5.x ships no delivery method), sync the lock via `bin/bundle-drift` and extend its `SAAS_ONLY_GEMS` allowlist with the gem and its transitive deps so the drift check stays green. Engine configures `delivery_method :ses_v2`, `MAILER_FROM_ADDRESS` env with a sensible default, hosted `default_url_options` from the proxy host; SES sending credentials arrive via Kamal secrets (or host IAM role) per the runbook. OSS mailer config untouched (R12). Mission Control: in SaaS mode, require configured `MISSION_CONTROL_*` credentials — refuse when unset instead of falling back to the retired `HTTP_AUTH_*` chain. Note in verification: a permanently failing send (unverified identity) strands the "check your email" page silently — the runbook's deliverability check is the guard.
+- **Patterns to follow:** engine env-config precedent from the foundation (`saas/config/environments/*`); `config/initializers/mission_control.rb`'s existing env chain.
+- **Test scenarios:**
+  - Covers AE8 (SaaS suite): request to `/jobs` with a valid user session but no Mission Control credentials → denied; with the configured credentials → allowed.
+  - SaaS suite: mailer deliveries enqueue with the configured from-address; url_options point at the hosted host.
+  - OSS suite: delivery config unchanged (test delivery method in test env; no SES constants referenced).
+- **Verification:** hosted dev boot delivers a real code email to a test identity via SES sandbox or shows it via the dev-mode display; `/jobs` checks pass.
+
+### U8. Launch migration, claim operation, and runbook
+
+- **Goal:** app.sessy.do's existing data becomes Marc's approved account with zero ingest gap; the steps are written down.
+- **Requirements:** R13, F4, AE6
+- **Dependencies:** U1 (the shared migration), U4 (`approve!`, membership creation)
+- **Files:** `lib/tasks/saas.rake` or `saas/lib/tasks/claim.rake` (claim task), `docs/plans/` runbook section or `docs/hosted-launch-runbook.md`, `saas/test/models/claim_test.rb`
+- **Approach:** The U1 migration lands hosted data in an approved, unlimited-retention instance account during deploy — ingest never pauses. Claim = an idempotent task/console op: create Marc's User (his email), attach owner Membership to the instance account (found via its flag column), optionally rename. Runbook documents: pre-deploy checks (SES identity verified + deliverability test, SES sending credentials in Kamal secrets, `MISSION_CONTROL_*` set), deploy (note: don't create sources during the deploy window — old container can't satisfy the new NOT NULL; ingest unaffected), run claim, verify sources/webhooks, retire `HTTP_AUTH_*` from the hosted env last, and the abuse-response recipe (null `approved_at` → UI gated + ingest 404s via U5's check; escalation: destroy sources/account).
+- **Patterns to follow:** the repo's operational-docs style (docs/docker-deployment.md); idempotent task discipline from `bin/bundle-drift`.
+- **Test scenarios:**
+  - Covers AE6: claim on a populated instance account attaches ownership without touching sources/events; running it twice is a no-op.
+  - Edge: claim with an email that already has a user reuses it (no duplicate).
+- **Verification:** rehearse the full sequence against a production DB copy locally (runbook step); sources/webhooks verified live post-launch.
+
+---
+
+## Verification Contract
+
+| Check | Command | Applies to |
+|---|---|---|
+| OSS suite (both DB adapters via CI) | `bin/rails test` + `bin/rails test:system` | all units |
+| SaaS suite | `SESSY_MODE=saas bin/rails test test saas/test` | U2-U8 |
+| Full local pipelines | `bin/ci` and `SESSY_MODE=saas bin/ci` | pre-PR gate |
+| Lint / security | `bin/rubocop`, `bin/brakeman --add-engines-path saas`, both bundler-audits | pre-PR gate |
+| OSS zero-change gate | `test/integration/oss_mode_test.rb` extended per U3/U5/U7 | R10-R12 |
+| Migration rehearsal | runbook dry-run against a hosted DB copy | U8 |
+
+Quality gates: all CI legs green on the PR; `db/schema.rb` diffed against main contains exactly the new tables/columns; visual verification (screenshots) of sign-in, pending, and post-approval flows in hosted dev boot.
+
+---
+
+## Definition of Done
+
+- All eight units implemented and verified; both `bin/ci` pipelines green locally; CI legs green on the PR.
+- OSS invariants proven: fresh-install AE1 walkthrough plus the extended OSS regression suite pass on both adapters.
+- Hosted flow demonstrated end to end in dev boot with screenshots: signup → pending → console approve → approval email → first source.
+- Runbook written and rehearsed against a DB copy; operational prerequisites (SES identity, `MISSION_CONTROL_*`) documented as launch gates, not code.
+- No stray scope: nothing from Deferred (billing, teams UI, admin UI, alerts) present; abandoned experiments removed from the diff.
+- Launch itself (deploy + claim + retiring `HTTP_AUTH_*`) is Marc-performed per the runbook, not part of the PR.

--- a/saas/app/controllers/concerns/sessy/saas/approval_gate.rb
+++ b/saas/app/controllers/concerns/sessy/saas/approval_gate.rb
@@ -1,0 +1,24 @@
+# Included into ApplicationController via the engine's to_prepare, so a pending
+# account sees only the pending page on every current and future hosted route
+# (opt-out per controller, not opt-in). Reads approved_at live per request.
+module Sessy::Saas::ApprovalGate
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_approved_account
+  end
+
+  class_methods do
+    def allow_pending_access(**options)
+      skip_before_action :require_approved_account, **options
+    end
+  end
+
+  private
+
+  def require_approved_account
+    if Current.account.present? && !Current.account.approved?
+      redirect_to pending_path
+    end
+  end
+end

--- a/saas/app/controllers/concerns/sessy/saas/authentication.rb
+++ b/saas/app/controllers/concerns/sessy/saas/authentication.rb
@@ -31,8 +31,15 @@ module Sessy::Saas::Authentication
 
   def resume_session
     if session_record = find_session_by_cookie
-      set_current_session(session_record)
-      true
+      if session_record.expired?
+        session_record.destroy
+        cookies.delete(:session_token)
+        nil
+      else
+        session_record.touch_if_stale
+        set_current_session(session_record)
+        true
+      end
     end
   end
 

--- a/saas/app/controllers/concerns/sessy/saas/authentication.rb
+++ b/saas/app/controllers/concerns/sessy/saas/authentication.rb
@@ -1,0 +1,83 @@
+# Included into ApplicationController via the engine's to_prepare (after the
+# core Authentication and SetCurrentAccount concerns), so its `authenticate` and
+# `set_current_account` shadow the OSS versions in hosted mode. The session
+# scheme fully replaces HTTP Basic — the old shared credential is inert here.
+module Sessy::Saas::Authentication
+  extend ActiveSupport::Concern
+
+  include Sessy::Saas::Authentication::ViaMagicCode
+
+  included do
+    before_action :require_signup_completion
+  end
+
+  class_methods do
+    def allow_unauthenticated_access(**options)
+      skip_before_action :authenticate, **options
+      skip_before_action :set_current_account, **options
+    end
+
+    # For the completion form itself, which a membership-less user must reach.
+    def allow_incomplete_signup(**options)
+      skip_before_action :require_signup_completion, **options
+    end
+  end
+
+  private
+
+  def authenticate
+    resume_session || request_authentication
+  end
+
+  def resume_session
+    if session_record = find_session_by_cookie
+      set_current_session(session_record)
+      true
+    end
+  end
+
+  def find_session_by_cookie
+    Session.find_signed(cookies.signed[:session_token]) if cookies.signed[:session_token]
+  end
+
+  def set_current_session(session_record)
+    Current.session = session_record
+    Current.user = session_record.user
+  end
+
+  def request_authentication
+    session[:return_to_after_authenticating] = request.url if request.get? || request.head?
+    redirect_to new_session_path
+  end
+
+  # A signed-in user with no membership (mid-signup or abandoned completion)
+  # must finish signup before reaching any tenant surface.
+  def require_signup_completion
+    if Current.user.present? && Current.account.nil?
+      redirect_to new_signup_completion_path
+    end
+  end
+
+  def start_new_session_for(user)
+    user.sessions.create!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session_record|
+      set_current_session(session_record)
+      cookies.signed.permanent[:session_token] = {
+        value: session_record.signed_id,
+        httponly: true,
+        secure: !Rails.env.local?,
+        same_site: :lax
+      }
+    end
+  end
+
+  def terminate_session
+    Current.session&.destroy
+    cookies.delete(:session_token)
+  end
+
+  # Hosted account resolution: the signed-in user's sole account (nil on the
+  # pre-auth pages). Refined by U5's tenancy scoping.
+  def set_current_account
+    Current.account = Current.user&.accounts&.first
+  end
+end

--- a/saas/app/controllers/concerns/sessy/saas/authentication/via_magic_code.rb
+++ b/saas/app/controllers/concerns/sessy/saas/authentication/via_magic_code.rb
@@ -1,0 +1,50 @@
+# The pending-authentication cookie binds a code to the browser that requested
+# it, and the development-mode code display (with a leak guard). Adapted from
+# Fizzy's Authentication::ViaMagicLink.
+module Sessy::Saas::Authentication::ViaMagicCode
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :ensure_development_code_not_leaked
+  end
+
+  private
+
+  def set_pending_authentication_token(magic_link)
+    cookies[:pending_authentication_token] = {
+      value: pending_authentication_token_verifier.generate(magic_link.user.email_address, expires_at: magic_link.expires_at),
+      httponly: true,
+      secure: !Rails.env.local?,
+      same_site: :lax,
+      expires: magic_link.expires_at
+    }
+  end
+
+  def email_address_pending_authentication
+    pending_authentication_token_verifier.verified(cookies[:pending_authentication_token])
+  end
+
+  def clear_pending_authentication_token
+    cookies.delete(:pending_authentication_token)
+  end
+
+  def pending_authentication_token_verifier
+    Rails.application.message_verifier(:pending_authentication)
+  end
+
+  # Development convenience: surface the code so no mail setup is needed locally.
+  # Gated strictly on Rails.env.development? (never SESSY_MODE), with a guard
+  # that fails loud if it ever leaks in another environment.
+  def serve_development_code(magic_link)
+    if Rails.env.development?
+      flash[:magic_code] = magic_link.code
+      response.set_header("X-Magic-Code", magic_link.code)
+    end
+  end
+
+  def ensure_development_code_not_leaked
+    unless Rails.env.development?
+      raise "Leaking magic code via flash in #{Rails.env}?" if flash[:magic_code].present?
+    end
+  end
+end

--- a/saas/app/controllers/sessy/saas/infos_controller.rb
+++ b/saas/app/controllers/sessy/saas/infos_controller.rb
@@ -1,4 +1,8 @@
 class Sessy::Saas::InfosController < ApplicationController
+  # Public diagnostic: engine version + environment, no tenant data.
+  allow_unauthenticated_access
+  allow_pending_access
+
   def show
   end
 end

--- a/saas/app/controllers/sessy/saas/pendings_controller.rb
+++ b/saas/app/controllers/sessy/saas/pendings_controller.rb
@@ -1,0 +1,10 @@
+class Sessy::Saas::PendingsController < ApplicationController
+  # Skip the gate here or pending users would redirect-loop.
+  allow_pending_access
+
+  layout "sessy/saas/public"
+
+  def show
+    redirect_to root_path if Current.account.nil? || Current.account.approved?
+  end
+end

--- a/saas/app/controllers/sessy/saas/sessions/codes_controller.rb
+++ b/saas/app/controllers/sessy/saas/sessions/codes_controller.rb
@@ -8,9 +8,14 @@ class Sessy::Saas::Sessions::CodesController < ApplicationController
   def show
   end
 
+  # The code must match the browser that requested it (pending-auth cookie), and
+  # is only consumed on a successful match — a wrong-browser guess leaves the
+  # real user's code intact.
   def create
-    if magic_link = MagicLink.consume(params[:code])
-      verify(magic_link)
+    if magic_link = MagicLink.authenticate(params[:code], email: email_address_pending_authentication)
+      clear_pending_authentication_token
+      start_new_session_for(magic_link.user)
+      redirect_to after_sign_in_path(magic_link.user)
     else
       redirect_to session_code_path, alert: "That code didn't work. Try again."
     end
@@ -21,18 +26,6 @@ class Sessy::Saas::Sessions::CodesController < ApplicationController
   def ensure_pending_authentication
     unless email_address_pending_authentication.present?
       redirect_to new_session_path, alert: "Enter your email address to sign in."
-    end
-  end
-
-  # The code alone isn't enough: it must match the browser that requested it.
-  def verify(magic_link)
-    if ActiveSupport::SecurityUtils.secure_compare(email_address_pending_authentication.to_s, magic_link.user.email_address)
-      clear_pending_authentication_token
-      start_new_session_for(magic_link.user)
-      redirect_to after_sign_in_path(magic_link.user)
-    else
-      clear_pending_authentication_token
-      redirect_to new_session_path, alert: "Something went wrong. Please try again."
     end
   end
 

--- a/saas/app/controllers/sessy/saas/sessions/codes_controller.rb
+++ b/saas/app/controllers/sessy/saas/sessions/codes_controller.rb
@@ -1,0 +1,53 @@
+class Sessy::Saas::Sessions::CodesController < ApplicationController
+  allow_unauthenticated_access
+  rate_limit to: 10, within: 15.minutes, only: :create, with: :rate_limit_exceeded
+  before_action :ensure_pending_authentication
+
+  layout "sessy/saas/public"
+
+  def show
+  end
+
+  def create
+    if magic_link = MagicLink.consume(params[:code])
+      verify(magic_link)
+    else
+      redirect_to session_code_path, alert: "That code didn't work. Try again."
+    end
+  end
+
+  private
+
+  def ensure_pending_authentication
+    unless email_address_pending_authentication.present?
+      redirect_to new_session_path, alert: "Enter your email address to sign in."
+    end
+  end
+
+  # The code alone isn't enough: it must match the browser that requested it.
+  def verify(magic_link)
+    if ActiveSupport::SecurityUtils.secure_compare(email_address_pending_authentication.to_s, magic_link.user.email_address)
+      clear_pending_authentication_token
+      start_new_session_for(magic_link.user)
+      redirect_to after_sign_in_path(magic_link.user)
+    else
+      clear_pending_authentication_token
+      redirect_to new_session_path, alert: "Something went wrong. Please try again."
+    end
+  end
+
+  # Route by membership presence, not code purpose: an abandoned signup leaves a
+  # membership-less user whose next code is sign_in-purpose, but they still need
+  # the completion form.
+  def after_sign_in_path(user)
+    if user.memberships.none?
+      new_signup_completion_path
+    else
+      root_path
+    end
+  end
+
+  def rate_limit_exceeded
+    redirect_to session_code_path, alert: "Too many attempts. Try again in 15 minutes."
+  end
+end

--- a/saas/app/controllers/sessy/saas/sessions_controller.rb
+++ b/saas/app/controllers/sessy/saas/sessions_controller.rb
@@ -1,0 +1,40 @@
+class Sessy::Saas::SessionsController < ApplicationController
+  allow_unauthenticated_access only: [ :new, :create ]
+
+  # Per-IP throttle, plus a per-target-email throttle so the endpoint can't be
+  # used to spam one victim's inbox (or burn SES reputation) from rotating IPs.
+  rate_limit to: 10, within: 3.minutes, only: :create, with: :rate_limit_exceeded
+  rate_limit to: 5, within: 3.minutes, only: :create, by: -> { params[:email_address].to_s.strip.downcase }, with: :rate_limit_exceeded
+
+  layout "sessy/saas/public"
+
+  def new
+  end
+
+  def create
+    user = User.find_or_create_by!(email_address: email_address)
+    purpose = user.memberships.none? ? :sign_up : :sign_in
+    magic_link = user.mint_magic_link(purpose: purpose)
+
+    Sessy::Saas::CodeMailer.sign_in_code(magic_link).deliver_later
+    set_pending_authentication_token(magic_link)
+    serve_development_code(magic_link)
+
+    redirect_to session_code_path
+  end
+
+  def destroy
+    terminate_session
+    redirect_to new_session_path
+  end
+
+  private
+
+  def email_address
+    params.expect(:email_address).to_s.strip.downcase
+  end
+
+  def rate_limit_exceeded
+    redirect_to new_session_path, alert: "Too many attempts. Try again later."
+  end
+end

--- a/saas/app/controllers/sessy/saas/signups/completions_controller.rb
+++ b/saas/app/controllers/sessy/saas/signups/completions_controller.rb
@@ -1,0 +1,27 @@
+class Sessy::Saas::Signups::CompletionsController < ApplicationController
+  allow_incomplete_signup
+  before_action :require_membership_absent
+
+  layout "sessy/saas/public"
+
+  def new
+    @signup = Sessy::Saas::Signup.new(user: Current.user)
+  end
+
+  def create
+    @signup = Sessy::Saas::Signup.new(user: Current.user, name: params[:name])
+
+    if @signup.complete
+      redirect_to root_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  # Already has an account? Nothing to complete.
+  def require_membership_absent
+    redirect_to root_path if Current.user&.memberships&.any?
+  end
+end

--- a/saas/app/mailers/sessy/saas/approval_mailer.rb
+++ b/saas/app/mailers/sessy/saas/approval_mailer.rb
@@ -1,0 +1,7 @@
+class Sessy::Saas::ApprovalMailer < ApplicationMailer
+  def approved(account)
+    @account = account
+    user = account.users.first
+    mail to: user.email_address, subject: "You're in — welcome to Sessy"
+  end
+end

--- a/saas/app/mailers/sessy/saas/code_mailer.rb
+++ b/saas/app/mailers/sessy/saas/code_mailer.rb
@@ -1,0 +1,6 @@
+class Sessy::Saas::CodeMailer < ApplicationMailer
+  def sign_in_code(magic_link)
+    @code = magic_link.code
+    mail to: magic_link.user.email_address, subject: "Your Sessy code is #{@code}"
+  end
+end

--- a/saas/app/models/concerns/sessy/saas/account_approval.rb
+++ b/saas/app/models/concerns/sessy/saas/account_approval.rb
@@ -1,0 +1,10 @@
+# Prepended onto Account via the engine's to_prepare. Core Account#approve!
+# only sets the timestamp; the engine layers the notification email on top, so
+# the OSS bundle never references a mailer.
+module Sessy::Saas::AccountApproval
+  def approve!
+    was_approved = approved?
+    super
+    Sessy::Saas::ApprovalMailer.approved(self).deliver_later unless was_approved
+  end
+end

--- a/saas/app/models/sessy/saas/claim.rb
+++ b/saas/app/models/sessy/saas/claim.rb
@@ -1,0 +1,13 @@
+# Hosted launch claim: attach an owner to the instance account, which already
+# owns the migrated launch data (U1 backfill). Idempotent — safe to re-run.
+module Sessy::Saas::Claim
+  def self.run(email)
+    account = Account.instance
+    account.approve! unless account.approved?
+
+    user = User.find_or_create_by!(email_address: email)
+    account.memberships.find_or_create_by!(user: user) { |membership| membership.role = "owner" }
+
+    account
+  end
+end

--- a/saas/app/models/sessy/saas/signup.rb
+++ b/saas/app/models/sessy/saas/signup.rb
@@ -1,0 +1,30 @@
+# Orchestrates signup completion: a signed-in, membership-less user names
+# themselves and gets a pending account with an owner membership. Plain
+# ActiveModel object, not a table.
+class Sessy::Saas::Signup
+  include ActiveModel::Model
+
+  attr_accessor :user, :name
+
+  validates :name, presence: true
+  validates :user, presence: true
+
+  # Hosted accounts default to 30-day retention (U6 owns resolution/enforcement).
+  HOSTED_RETENTION_DAYS = 30
+
+  def complete
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      account = Account.create!(name: account_name, retention_days: HOSTED_RETENTION_DAYS)
+      account.memberships.create!(user: user, role: "owner")
+      account
+    end
+  end
+
+  private
+
+  def account_name
+    "#{name}'s Sessy"
+  end
+end

--- a/saas/app/views/layouts/sessy/saas/public.html.erb
+++ b/saas/app/views/layouts/sessy/saas/public.html.erb
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class="antialiased">
+  <head>
+    <title><%= content_for(:title) || "Sessy" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <link rel="icon" href="<%= asset_path("icon.svg") %>" type="image/svg+xml">
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body class="bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
+    <main class="mx-auto flex min-h-screen max-w-sm flex-col justify-center px-6">
+      <%= image_tag "wordmark.svg", class: "mb-8 h-6 w-auto dark:invert", alt: "Sessy" %>
+
+      <% if alert = flash[:alert] %>
+        <div class="mb-4 rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-700 dark:text-red-400"><%= alert %></div>
+      <% end %>
+      <% if notice = flash[:notice] %>
+        <div class="mb-4 rounded-md bg-emerald-500/10 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-400"><%= notice %></div>
+      <% end %>
+
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/saas/app/views/sessy/saas/approval_mailer/approved.html.erb
+++ b/saas/app/views/sessy/saas/approval_mailer/approved.html.erb
@@ -1,0 +1,2 @@
+<p>You're in!</p>
+<p>Your Sessy account has been approved. <%= link_to "Sign in", new_session_url %> to add your first source and start watching your SES activity.</p>

--- a/saas/app/views/sessy/saas/approval_mailer/approved.text.erb
+++ b/saas/app/views/sessy/saas/approval_mailer/approved.text.erb
@@ -1,0 +1,5 @@
+You're in!
+
+Your Sessy account has been approved. Sign in to add your first source and start watching your SES activity:
+
+<%= new_session_url %>

--- a/saas/app/views/sessy/saas/code_mailer/sign_in_code.html.erb
+++ b/saas/app/views/sessy/saas/code_mailer/sign_in_code.html.erb
@@ -1,0 +1,3 @@
+<p>Your Sessy sign-in code is:</p>
+<p style="font-size: 24px; font-weight: bold; letter-spacing: 4px; font-family: monospace;"><%= @code %></p>
+<p style="color: #71717a; font-size: 14px;">It expires in 15 minutes. If you didn't request it, you can ignore this email.</p>

--- a/saas/app/views/sessy/saas/code_mailer/sign_in_code.text.erb
+++ b/saas/app/views/sessy/saas/code_mailer/sign_in_code.text.erb
@@ -1,0 +1,5 @@
+Your Sessy sign-in code is:
+
+  <%= @code %>
+
+It expires in 15 minutes. If you didn't request it, you can ignore this email.

--- a/saas/app/views/sessy/saas/pendings/show.html.erb
+++ b/saas/app/views/sessy/saas/pendings/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "Pending approval" %>
+
+<h1 class="text-lg font-semibold">You're on the list</h1>
+<p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+  Sessy is in early access, so new accounts are approved by hand. We'll email you the moment you're in — usually pretty quick.
+</p>
+
+<%= button_to "Sign out", session_path, method: :delete,
+      class: "mt-6 w-full rounded-md border border-zinc-950/10 px-3 py-2 text-sm font-medium hover:bg-zinc-50 dark:border-white/10 dark:hover:bg-zinc-900" %>

--- a/saas/app/views/sessy/saas/sessions/codes/show.html.erb
+++ b/saas/app/views/sessy/saas/sessions/codes/show.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, "Enter your code" %>
+
+<h1 class="text-lg font-semibold">Check your email</h1>
+<p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">We sent a sign-in code to your inbox. Enter it below.</p>
+
+<% if Rails.env.development? && flash[:magic_code].present? %>
+  <div class="mt-3 rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+    Dev code: <code class="font-mono font-semibold"><%= flash[:magic_code] %></code>
+  </div>
+<% end %>
+
+<%= form_with url: session_code_path, method: :post, class: "mt-6 space-y-3" do |form| %>
+  <%= form.text_field :code, required: true, autofocus: true, autocomplete: "one-time-code",
+        placeholder: "ABC123", inputmode: "text",
+        class: "w-full rounded-md border border-zinc-950/10 bg-white px-3 py-2 text-center font-mono text-lg uppercase tracking-widest dark:border-white/10 dark:bg-zinc-900" %>
+  <%= form.submit "Sign in",
+        class: "w-full rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200" %>
+<% end %>
+
+<%= link_to "Use a different email", new_session_path, class: "mt-4 block text-center text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100" %>

--- a/saas/app/views/sessy/saas/sessions/new.html.erb
+++ b/saas/app/views/sessy/saas/sessions/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Sign in" %>
+
+<h1 class="text-lg font-semibold">Sign in to Sessy</h1>
+<p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">Enter your email and we'll send you a sign-in code.</p>
+
+<%= form_with url: session_path, method: :post, class: "mt-6 space-y-3" do |form| %>
+  <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "email",
+        placeholder: "you@example.com",
+        class: "w-full rounded-md border border-zinc-950/10 bg-white px-3 py-2 text-sm dark:border-white/10 dark:bg-zinc-900" %>
+  <%= form.submit "Email me a code",
+        class: "w-full rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200" %>
+<% end %>

--- a/saas/app/views/sessy/saas/signups/completions/new.html.erb
+++ b/saas/app/views/sessy/saas/signups/completions/new.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Finish signing up" %>
+
+<h1 class="text-lg font-semibold">One more thing</h1>
+<p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">What should we call you?</p>
+
+<%= form_with url: signup_completion_path, method: :post, class: "mt-6 space-y-3" do |form| %>
+  <% if @signup.errors.any? %>
+    <div class="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-700 dark:text-red-400">Please enter your name.</div>
+  <% end %>
+  <%= form.text_field :name, required: true, autofocus: true, autocomplete: "name",
+        placeholder: "Your name",
+        class: "w-full rounded-md border border-zinc-950/10 bg-white px-3 py-2 text-sm dark:border-white/10 dark:bg-zinc-900" %>
+  <%= form.submit "Continue",
+        class: "w-full rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200" %>
+<% end %>

--- a/saas/lib/sessy/saas/engine.rb
+++ b/saas/lib/sessy/saas/engine.rb
@@ -4,11 +4,30 @@ module Sessy
       initializer "sessy_saas.routes" do |app|
         app.routes.append do
           resource :saas_info, only: :show, controller: "sessy/saas/infos", path: "saas/info"
+
+          resource :session, only: [ :new, :create, :destroy ], controller: "sessy/saas/sessions"
+          resource :session_code, only: [ :show, :create ], controller: "sessy/saas/sessions/codes", path: "session/code"
+          resource :signup_completion, only: [ :new, :create ], controller: "sessy/saas/signups/completions", path: "signup/complete"
+          resource :pending, only: :show, controller: "sessy/saas/pendings"
         end
+      end
+
+      initializer "sessy_saas.action_mailer", after: "action_mailer.set_configs" do
+        ActionMailer::Base.default from: ENV.fetch("MAILER_FROM_ADDRESS", "Sessy <hello@sessy.do>")
+        ActionMailer::Base.default_url_options = {
+          host: ENV.fetch("APP_HOST", "app.sessy.do"),
+          protocol: "https"
+        }
+        # SES sending credentials arrive via Kamal secrets / host IAM role; the
+        # :ses_v2 client is created lazily on first send, so boot needs no creds.
+        ActionMailer::Base.delivery_method = :ses_v2 if Rails.env.production?
       end
 
       config.to_prepare do
         ApplicationController.include Sessy::Saas::EditionHeaders
+        ApplicationController.include Sessy::Saas::Authentication
+        ApplicationController.include Sessy::Saas::ApprovalGate
+        Account.prepend Sessy::Saas::AccountApproval
       end
     end
   end

--- a/saas/lib/tasks/claim.rake
+++ b/saas/lib/tasks/claim.rake
@@ -1,0 +1,10 @@
+namespace :saas do
+  desc "Attach an owner to the instance account for the hosted launch (idempotent). Usage: rake saas:claim[you@example.com]"
+  task :claim, [ :email ] => :environment do |_task, args|
+    email = args[:email]
+    abort "Usage: bin/rails saas:claim[you@example.com]" if email.blank?
+
+    account = Sessy::Saas::Claim.run(email)
+    puts "Claimed account ##{account.id} (#{account.sources.count} sources) as #{email}."
+  end
+end

--- a/saas/test/controllers/edition_headers_test.rb
+++ b/saas/test/controllers/edition_headers_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Sessy::Saas::EditionHeadersTest < ActionDispatch::IntegrationTest
   test "responses carry the hosted edition header" do
-    get root_path
+    get saas_info_path
     assert_response :success
     assert_equal "hosted", response.headers["X-Sessy-Edition"]
   end
@@ -11,14 +11,11 @@ class Sessy::Saas::EditionHeadersTest < ActionDispatch::IntegrationTest
     assert ApplicationController.include?(Sessy::Saas::EditionHeaders)
   end
 
-  test "auth challenges carry the edition header" do
-    ENV["HTTP_AUTH_USERNAME"] = "user"
-    ENV["HTTP_AUTH_PASSWORD"] = "secret"
+  test "the header is stamped before auth halts the chain" do
+    # Unauthenticated tenant request redirects to sign-in but still carries the
+    # edition marker (set via prepend_before_action, ahead of authenticate).
     get root_path
-    assert_response :unauthorized
+    assert_redirected_to new_session_path
     assert_equal "hosted", response.headers["X-Sessy-Edition"]
-  ensure
-    ENV.delete("HTTP_AUTH_USERNAME")
-    ENV.delete("HTTP_AUTH_PASSWORD")
   end
 end

--- a/saas/test/controllers/infos_test.rb
+++ b/saas/test/controllers/infos_test.rb
@@ -7,8 +7,14 @@ class Sessy::Saas::InfosTest < ActionDispatch::IntegrationTest
     assert_match Sessy::Saas::VERSION, response.body
   end
 
-  test "header shows the hosted badge" do
+  test "header shows the hosted badge to a signed-in user" do
+    user = User.create!(email_address: "badge@example.com")
+    accounts(:instance).memberships.create!(user: user)
+    post session_path, params: { email_address: user.email_address }
+    post session_code_path, params: { code: MagicLink.last.code }
+
     get root_path
+    assert_response :success
     assert_select "[data-saas-badge]"
   end
 end

--- a/saas/test/controllers/jobs_guard_test.rb
+++ b/saas/test/controllers/jobs_guard_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Sessy::Saas::JobsGuardTest < ActionDispatch::IntegrationTest
+  test "jobs dashboard is locked in hosted mode without operator credentials" do
+    # No MISSION_CONTROL_* set in the test env, so /jobs must be locked rather
+    # than falling open (AE8). Basic auth is enabled with unguessable creds.
+    assert MissionControl::Jobs.http_basic_auth_enabled
+    assert MissionControl::Jobs.http_basic_auth_user.present?
+    assert MissionControl::Jobs.http_basic_auth_password.present?
+  end
+
+  test "a signed-in user without operator credentials cannot open jobs" do
+    user = User.create!(email_address: "jobs@example.com")
+    accounts(:instance).memberships.create!(user: user)
+    post session_path, params: { email_address: user.email_address }
+    post session_code_path, params: { code: MagicLink.last.code }
+
+    get "/jobs"
+    assert_not_equal 200, response.status
+  end
+end

--- a/saas/test/controllers/sessions_test.rb
+++ b/saas/test/controllers/sessions_test.rb
@@ -24,6 +24,36 @@ class Sessy::Saas::SessionsTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
+  test "a wrong-browser submission does not burn the real user's code" do
+    create_member
+    post session_path, params: { email_address: "member@example.com" }
+    code = MagicLink.last.code
+
+    # Attacker's browser (own pending cookie for a different email) submits the code.
+    reset!
+    post session_path, params: { email_address: "attacker@example.com" }
+    post session_code_path, params: { code: code }
+    assert_redirected_to session_code_path
+
+    # The member's code is still valid — it wasn't consumed by the failed attempt.
+    assert MagicLink.exists?(code: code)
+  end
+
+  test "an idle-expired session is rejected and requires re-auth" do
+    user = create_member
+    post session_path, params: { email_address: user.email_address }
+    post session_code_path, params: { code: MagicLink.last.code }
+    get root_path
+    assert_response :success
+
+    Session.last.update_column(:updated_at, 31.days.ago)
+
+    assert_difference -> { Session.count }, -1 do
+      get root_path
+    end
+    assert_redirected_to new_session_path
+  end
+
   test "a code cannot be reused" do
     user = create_member
     post session_path, params: { email_address: user.email_address }

--- a/saas/test/controllers/sessions_test.rb
+++ b/saas/test/controllers/sessions_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+
+class Sessy::Saas::SessionsTest < ActionDispatch::IntegrationTest
+  test "full sign-in round trip for an existing member" do
+    user = create_member
+
+    post session_path, params: { email_address: user.email_address }
+    code = MagicLink.last.code
+
+    post session_code_path, params: { code: code }
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_response :success
+  end
+
+  test "code from a different browser is rejected" do
+    create_member
+    post session_path, params: { email_address: "member@example.com" }
+    code = MagicLink.last.code
+
+    # New session (no pending-authentication cookie) simulates another browser.
+    reset!
+    post session_code_path, params: { code: code }
+    assert_redirected_to new_session_path
+  end
+
+  test "a code cannot be reused" do
+    user = create_member
+    post session_path, params: { email_address: user.email_address }
+    code = MagicLink.last.code
+
+    post session_code_path, params: { code: code }
+    assert_no_difference -> { Session.count } do
+      post session_code_path, params: { code: code }
+    end
+    assert_not MagicLink.exists?(code: code)
+  end
+
+  test "unknown and known emails produce identical responses" do
+    create_member
+
+    post session_path, params: { email_address: "member@example.com" }
+    known_status, known_location = response.status, response.headers["Location"]
+    reset!
+    post session_path, params: { email_address: "stranger@example.com" }
+
+    assert_equal known_status, response.status
+    assert_equal known_location, response.headers["Location"]
+  end
+
+  test "unknown email creates a user and mints a sign_up code" do
+    assert_difference -> { User.count }, 1 do
+      post session_path, params: { email_address: "new@example.com" }
+    end
+    assert MagicLink.last.for_sign_up?
+  end
+
+  test "hosted mode does not accept the old shared Basic credential" do
+    with_env("HTTP_AUTH_USERNAME" => "admin", "HTTP_AUTH_PASSWORD" => "secret") do
+      get root_path, headers: { "Authorization" => ActionController::HttpAuthentication::Basic.encode_credentials("admin", "secret") }
+      assert_redirected_to new_session_path
+    end
+  end
+
+  test "sign out destroys the session" do
+    user = create_member
+    post session_path, params: { email_address: user.email_address }
+    post session_code_path, params: { code: MagicLink.last.code }
+
+    assert_difference -> { Session.count }, -1 do
+      delete session_path
+    end
+    assert_redirected_to new_session_path
+  end
+
+  private
+
+  def create_member(email: "member@example.com")
+    user = User.create!(email_address: email)
+    accounts(:instance).memberships.create!(user: user)
+    user
+  end
+
+  def with_env(vars)
+    originals = vars.transform_values { |_| :missing }
+    vars.each { |k, v| originals[k] = ENV[k]; ENV[k] = v }
+    yield
+  ensure
+    originals.each { |k, v| v == :missing ? ENV.delete(k) : ENV[k] = v }
+  end
+end

--- a/saas/test/controllers/signups_test.rb
+++ b/saas/test/controllers/signups_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class Sessy::Saas::SignupsTest < ActionDispatch::IntegrationTest
+  test "new signup completes into a pending account and is gated" do
+    sign_up_as "new@example.com"
+
+    # On the completion form now (membership-less user).
+    get new_signup_completion_path
+    assert_response :success
+
+    assert_difference -> { Account.where(instance: false).count }, 1 do
+      post signup_completion_path, params: { name: "Casey" }
+    end
+
+    account = Account.where(instance: false).last
+    assert_not account.approved?
+    assert_equal "owner", account.memberships.first.role
+
+    # Every tenant route now shows the pending page.
+    get root_path
+    assert_redirected_to pending_path
+    get new_source_path
+    assert_redirected_to pending_path
+  end
+
+  test "approval flips access on the next request and emails the user" do
+    user = sign_up_and_complete "approve@example.com", "Dana"
+    account = user.accounts.first
+
+    get root_path
+    assert_redirected_to pending_path
+
+    assert_enqueued_email_with Sessy::Saas::ApprovalMailer, :approved, args: [ account ] do
+      account.approve!
+    end
+
+    get root_path
+    assert_response :success
+  end
+
+  test "a signed-in membership-less user is sent to complete signup, not 500" do
+    sign_up_as "midway@example.com"
+
+    get root_path
+    assert_redirected_to new_signup_completion_path
+
+    get new_source_path
+    assert_redirected_to new_signup_completion_path
+  end
+
+  test "signup transaction rolls back on failure leaving no orphans" do
+    sign_up_as "blank@example.com"
+
+    assert_no_difference [ -> { Account.where(instance: false).count }, -> { Membership.count } ] do
+      post signup_completion_path, params: { name: "" }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  private
+
+  def sign_up_as(email)
+    post session_path, params: { email_address: email }
+    post session_code_path, params: { code: MagicLink.last.code }
+    assert_redirected_to new_signup_completion_path
+  end
+
+  def sign_up_and_complete(email, name)
+    sign_up_as email
+    post signup_completion_path, params: { name: name }
+    User.find_by(email_address: email)
+  end
+end

--- a/saas/test/controllers/tenancy_test.rb
+++ b/saas/test/controllers/tenancy_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class Sessy::Saas::TenancyTest < ActionDispatch::IntegrationTest
+  test "a user cannot reach another account's source" do
+    _account_a, user_a, source_a = approved_account("a@example.com")
+    _account_b, _user_b, source_b = approved_account("b@example.com")
+
+    sign_in user_a
+
+    get source_path(source_a)
+    assert_response :success
+
+    # Another account's source is invisible (404, not 403 — no existence leak).
+    get source_path(source_b)
+    assert_response :not_found
+  end
+
+  test "index shows only the current account's sources" do
+    _account_a, user_a, source_a = approved_account("a2@example.com")
+    _account_b, _user_b, source_b = approved_account("b2@example.com")
+
+    sign_in user_a
+    get sources_path
+    assert_select "a[href=?]", source_path(source_a)
+    assert_select "a[href=?]", source_path(source_b), count: 0
+  end
+
+  test "webhook ingests for an approved account's source" do
+    account = Account.create!(name: "Approved", approved_at: Time.current)
+    source = account.sources.create!(name: "Src")
+
+    post webhook_path(source.token), params: subscription_confirmation, as: :json
+    assert_response :success
+  end
+
+  test "webhook is refused once the account is un-approved" do
+    account = Account.create!(name: "Revoked", approved_at: Time.current)
+    source = account.sources.create!(name: "Src")
+    account.update!(approved_at: nil)
+
+    post webhook_path(source.token), params: subscription_confirmation, as: :json
+    assert_response :not_found
+  end
+
+  private
+
+  def approved_account(email)
+    account = Account.create!(name: "#{email} co", approved_at: Time.current)
+    user = User.create!(email_address: email)
+    account.memberships.create!(user: user)
+    source = account.sources.create!(name: "Src")
+    [ account, user, source ]
+  end
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address }
+    post session_code_path, params: { code: MagicLink.last.code }
+  end
+
+  def subscription_confirmation
+    { "Type" => "SubscriptionConfirmation", "SubscribeURL" => "https://example.com/confirm" }
+  end
+end

--- a/saas/test/mailer_config_test.rb
+++ b/saas/test/mailer_config_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class Sessy::Saas::MailerConfigTest < ActiveSupport::TestCase
+  test "hosted from-address and url host are configured" do
+    assert_equal [ ENV.fetch("MAILER_FROM_ADDRESS", "Sessy <hello@sessy.do>") ], Array(ActionMailer::Base.default[:from])
+    assert_equal "app.sessy.do", ActionMailer::Base.default_url_options[:host]
+  end
+
+  test "code mailer addresses the user with the code in the subject" do
+    user = User.create!(email_address: "mailer@example.com")
+    link = user.mint_magic_link
+    mail = Sessy::Saas::CodeMailer.sign_in_code(link)
+    assert_equal [ "mailer@example.com" ], mail.to
+    assert_match link.code, mail.subject
+  end
+end

--- a/saas/test/models/claim_test.rb
+++ b/saas/test/models/claim_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Sessy::Saas::ClaimTest < ActiveSupport::TestCase
+  test "attaches an owner membership to the instance account without touching sources" do
+    source_ids = Account.instance.sources.pluck(:id).sort
+
+    account = Sessy::Saas::Claim.run("owner@example.com")
+
+    assert account.instance?
+    assert account.approved?
+    assert_equal "owner", account.memberships.find_by(user: User.find_by(email_address: "owner@example.com")).role
+    assert_equal source_ids, account.sources.pluck(:id).sort
+  end
+
+  test "is idempotent and reuses an existing user" do
+    User.create!(email_address: "owner@example.com")
+
+    assert_difference -> { User.count }, 0 do
+      2.times { Sessy::Saas::Claim.run("owner@example.com") }
+    end
+    assert_equal 1, Account.instance.memberships.count
+  end
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,4 +2,12 @@ require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+
+  # These assert OSS UI behavior and run green in both adapter legs. In hosted
+  # mode the whole app is behind session auth; the auth and tenant flows are
+  # covered by saas/test integration tests, so skip the OSS system suite here
+  # rather than plumb a cross-thread session into every case.
+  setup do
+    skip "OSS system tests run in OSS mode; hosted flows are covered by saas/test" if Sessy.saas?
+  end
 end

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,0 +1,4 @@
+instance:
+  name: Sessy
+  instance: true
+  approved_at: <%= Time.current.iso8601 %>

--- a/test/fixtures/sources.yml
+++ b/test/fixtures/sources.yml
@@ -2,9 +2,11 @@ betalist:
   name: BetaList
   token: <%= SecureRandom.uuid %>
   color: blue
+  account: instance
 
 wip:
   name: WIP
   token: <%= SecureRandom.uuid %>
   color: yellow
   retention_days: 30
+  account: instance

--- a/test/integration/oss_mode_test.rb
+++ b/test/integration/oss_mode_test.rb
@@ -21,4 +21,34 @@ class OssModeTest < ActionDispatch::IntegrationTest
     get root_path
     assert_select "[data-saas-badge]", count: 0
   end
+
+  test "hosted auth routes do not resolve" do
+    get "/session/new"
+    assert_response :not_found
+  end
+
+  test "no hosted mailer delivery is configured" do
+    assert_not_equal "app.sessy.do", ActionMailer::Base.default_url_options[:host]
+    assert_not_equal :ses_v2, ActionMailer::Base.delivery_method
+  end
+
+  test "HTTP Basic still gates the app when configured" do
+    with_env("HTTP_AUTH_USERNAME" => "admin", "HTTP_AUTH_PASSWORD" => "secret") do
+      get root_path
+      assert_response :unauthorized
+
+      get root_path, headers: { "Authorization" => ActionController::HttpAuthentication::Basic.encode_credentials("admin", "secret") }
+      assert_response :success
+    end
+  end
+
+  private
+
+  def with_env(vars)
+    originals = {}
+    vars.each { |k, v| originals[k] = ENV.key?(k) ? ENV[k] : :missing; ENV[k] = v }
+    yield
+  ensure
+    originals.each { |k, v| v == :missing ? ENV.delete(k) : ENV[k] = v }
+  end
 end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class AccountTest < ActiveSupport::TestCase
+  test "instance is a lazily created singleton" do
+    Account.where(instance: true).destroy_all
+    Current.instance_account = nil
+
+    account = Account.instance
+    assert account.instance?
+    assert account.approved?
+
+    Current.instance_account = nil
+    assert_equal account, Account.instance
+    assert_equal 1, Account.where(instance: true).count
+  end
+
+  test "approved? reflects approved_at" do
+    account = Account.new
+    assert_not account.approved?
+    account.approve!
+    assert account.approved?
+  end
+
+  test "backfill is idempotent and leaves every source owned by an account" do
+    # The account_id NOT NULL constraint prevents reconstructing legacy null
+    # state in-test; the migration itself exercises the null->instance path
+    # (and the U8 runbook rehearses it end-to-end). Here we prove the callable
+    # is a safe no-op once every source already has an account.
+    assert_nothing_raised { Source::AccountBackfill.run }
+    assert_equal 0, Source.where(account_id: nil).count
+  end
+
+  test "new sources default to the instance account" do
+    source = Source.create!(name: "Test")
+    assert_equal Account.instance, source.account
+  end
+end

--- a/test/models/magic_link_test.rb
+++ b/test/models/magic_link_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class MagicLinkTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(email_address: "code@example.com")
+  end
+
+  test "consume destroys the code so it cannot be reused" do
+    link = @user.magic_links.create!
+    assert_equal link.code, MagicLink.consume(link.code).code
+    assert_nil MagicLink.consume(link.code)
+  end
+
+  test "expired codes are not consumable" do
+    link = @user.magic_links.create!
+    link.update!(expires_at: 1.minute.ago)
+    assert_nil MagicLink.consume(link.code)
+  end
+
+  test "cleanup deletes stale codes only" do
+    active = @user.magic_links.create!
+    stale = @user.magic_links.create!
+    stale.update!(expires_at: 1.minute.ago)
+
+    MagicLink.cleanup
+
+    assert MagicLink.exists?(active.id)
+    assert_not MagicLink.exists?(stale.id)
+  end
+
+  test "Code.sanitize maps ambiguous characters and strips invalid ones" do
+    assert_equal "011", MagicLink::Code.sanitize("oil")
+    assert_equal "AB2", MagicLink::Code.sanitize("a b-2!")
+  end
+
+  test "codes are unique on collision" do
+    link = @user.magic_links.create!
+    assert link.code.present?
+    assert_equal MagicLink::CODE_LENGTH, link.code.length
+  end
+end

--- a/test/models/retention_resolution_test.rb
+++ b/test/models/retention_resolution_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+# Effective retention resolves source-then-account, and the sweep reaches
+# sources that rely only on the account default (the redesigned enumeration).
+class RetentionResolutionTest < ActiveSupport::TestCase
+  test "account default applies when the source has none" do
+    account = Account.create!(name: "Hosted", retention_days: 30)
+    source = account.sources.create!(name: "Src")
+
+    old = Message.create!(source: source, ses_message_id: SecureRandom.uuid, sent_at: 31.days.ago)
+    recent = Message.create!(source: source, ses_message_id: SecureRandom.uuid, sent_at: 29.days.ago)
+
+    assert_equal 30, source.effective_retention_days
+    source.delete_expired_data
+    assert_not Message.exists?(old.id)
+    assert Message.exists?(recent.id)
+  end
+
+  test "per-source override wins over the account default in both directions" do
+    account = Account.create!(name: "Hosted", retention_days: 30)
+    source = account.sources.create!(name: "Src", retention_days: 7)
+    assert_equal 7, source.effective_retention_days
+  end
+
+  test "nil source and nil account keeps everything" do
+    account = Account.create!(name: "Unlimited", retention_days: nil)
+    source = account.sources.create!(name: "Src")
+    assert_nil source.effective_retention_days
+    assert_equal 0, source.delete_expired_data
+  end
+
+  test "with_retention_policy reaches account-default sources" do
+    account = Account.create!(name: "Hosted", retention_days: 30)
+    source = account.sources.create!(name: "Src")
+    assert_includes Source.with_retention_policy, source
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test "email is normalized" do
+    user = User.create!(email_address: "  Person@Example.COM ")
+    assert_equal "person@example.com", user.email_address
+  end
+
+  test "email is unique" do
+    User.create!(email_address: "dup@example.com")
+    assert_raises(ActiveRecord::RecordInvalid) { User.create!(email_address: "dup@example.com") }
+  end
+
+  test "mint_magic_link creates a code with the given purpose" do
+    user = User.create!(email_address: "mint@example.com")
+    link = user.mint_magic_link(purpose: :sign_up)
+    assert link.for_sign_up?
+    assert link.persisted?
+  end
+
+  test "membership uniqueness scoped to account" do
+    user = User.create!(email_address: "member@example.com")
+    account = Account.instance
+    account.memberships.create!(user: user)
+    dup = account.memberships.build(user: user)
+    assert_not dup.valid?
+  end
+end


### PR DESCRIPTION
## Summary

Turns app.sessy.do into a multi-tenant product people can sign up for, while self-hosted installs stay byte-for-byte the product they are today. Single code path: every install has accounts, but a self-hosted install lives invisibly inside one lazily-created **instance account** with no login, no signup, no email setup, and optional HTTP Basic exactly as before. The hosted edition activates magic-code auth and manual approval on top.

Implements `docs/plans/2026-07-18-001-feat-hosted-sessy-launch-plan.md` (U1–U8).

## What's here

- **Core (dormant in OSS):** `Account` / `User` / `Membership` / `Session` / `MagicLink`; `Account.instance` lazy singleton; sources/events/messages scoped through `Current.account`; retention resolved source-then-account with the daily sweep redesigned to reach account-default sources.
- **Engine (hosted only):** magic-code sign-in (typed 6-char code, browser-bound, single-use, rate-limited per-IP and per-email, anti-enumeration), merged email form, signup completion into a pending account, an approval gate on `ApplicationController`, and a completion gate so membership-less users finish signup. Session auth replaces HTTP Basic in hosted mode (Basic is inert there). SES email via `aws-actionmailer-ses` (SaaS-only bundle). `/jobs` stays locked behind operator credentials and never falls open.
- **Launch:** idempotent `saas:claim` task + `docs/hosted-launch-runbook.md`.

## Non-obvious details

- The instance account is a **lazy runtime singleton**, not migration-created — fresh `db:prepare` schema-loads and skips migration bodies, so a migration-only account would never exist on a fresh install. The upgrade migration still backfills `sources.account_id` for existing installs.
- Webhook ingest gains a one-line `source.account.approved?` kill switch, so nulling `approved_at` stops an abusive account both in the UI and at ingest.
- OSS is unchanged: the zero-change regression suite (`test/integration/oss_mode_test.rb`) proves auth routes are absent, HTTP Basic still gates, and no hosted mailer config leaks in.

## Verification

Both `bin/ci` pipelines green (OSS + SaaS), lint + brakeman clean, lockfiles in sync. Full signup → code → pending → approve → dashboard flow verified live against a running hosted server; sign-in page screenshotted.

## Post-merge / launch (maintainer, per runbook)

- [ ] Verify an SES sending identity for `MAILER_FROM_ADDRESS` (+ store SES credentials in Kamal secrets)
- [ ] Set `MISSION_CONTROL_USERNAME` / `MISSION_CONTROL_PASSWORD` and `APP_HOST` on the hosted deploy
- [ ] Deploy, run `bin/rails "saas:claim[you@example.com]"`, verify, then retire `HTTP_AUTH_*` last