### PR TITLE
Show ready-to-paste MCP connect snippets on key creation

### DIFF
--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -1,7 +1,5 @@
 class DocsController < ApplicationController
   def mcp
-    api_host = Rails.configuration.x.api_host
-    @endpoint_url = api_host.present? ? "https://#{api_host}/mcp" : "#{request.base_url}/mcp"
     @tools = McpServer.tools
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  def mcp_endpoint_url
+    host = Rails.configuration.x.api_host
+    host.present? ? "https://#{host}/mcp" : "#{request.base_url}/mcp"
+  end
+
   def show_auth_warning?
     return false if Sessy.saas?
 

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -14,6 +14,27 @@
     <div class="mt-4 border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5 text-sm">
       <p class="font-medium text-emerald-700 dark:text-emerald-400">API key created. Copy it now &mdash; it won't be shown again.</p>
       <code class="mt-1 block select-all break-all text-zinc-900 dark:text-zinc-100"><%= flash[:api_key_token] %></code>
+
+      <p class="mt-4 font-medium text-zinc-900 dark:text-zinc-100">Or connect your editor in one paste:</p>
+
+      <p class="mt-3 text-zinc-500 dark:text-zinc-400">Claude Code</p>
+      <pre class="mt-1 border border-zinc-950/10 dark:border-white/10 bg-white dark:bg-zinc-950 px-3 py-2 overflow-x-auto"><code class="select-all">claude mcp add --transport http sessy <%= mcp_endpoint_url %> \
+  --header "Authorization: Bearer <%= flash[:api_key_token] %>"</code></pre>
+
+      <p class="mt-3 text-zinc-500 dark:text-zinc-400">Cursor &mdash; add to <code>~/.cursor/mcp.json</code></p>
+      <pre class="mt-1 border border-zinc-950/10 dark:border-white/10 bg-white dark:bg-zinc-950 px-3 py-2 overflow-x-auto"><code class="select-all">{
+  "mcpServers": {
+    "sessy": {
+      "url": "<%= mcp_endpoint_url %>",
+      "headers": { "Authorization": "Bearer <%= flash[:api_key_token] %>" }
+    }
+  }
+}</code></pre>
+
+      <p class="mt-3 text-zinc-500 dark:text-zinc-400">Codex &mdash; add to <code>~/.codex/config.toml</code></p>
+      <pre class="mt-1 border border-zinc-950/10 dark:border-white/10 bg-white dark:bg-zinc-950 px-3 py-2 overflow-x-auto"><code class="select-all">[mcp_servers.sessy]
+url = "<%= mcp_endpoint_url %>"
+http_headers = { "Authorization" = "Bearer <%= flash[:api_key_token] %>" }</code></pre>
     </div>
   <% end %>
 

--- a/app/views/docs/mcp.html.erb
+++ b/app/views/docs/mcp.html.erb
@@ -12,7 +12,7 @@
     <div class="space-y-6">
       <div>
         <h2 class="text-sm font-medium">Endpoint</h2>
-        <pre class="mt-2 border border-zinc-950/10 dark:border-white/10 px-3 py-2 text-sm overflow-x-auto"><code class="select-all"><%= @endpoint_url %></code></pre>
+        <pre class="mt-2 border border-zinc-950/10 dark:border-white/10 px-3 py-2 text-sm overflow-x-auto"><code class="select-all"><%= mcp_endpoint_url %></code></pre>
         <p class="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
           Authentication uses an API key as a bearer token.
           <%= link_to "Create one here", api_keys_path, class: "underline hover:text-zinc-900 dark:hover:text-zinc-100" %>.
@@ -21,7 +21,7 @@
 
       <div>
         <h2 class="text-sm font-medium">Claude Code</h2>
-        <pre class="mt-2 border border-zinc-950/10 dark:border-white/10 px-3 py-2 text-sm overflow-x-auto"><code>claude mcp add --transport http sessy <%= @endpoint_url %> \
+        <pre class="mt-2 border border-zinc-950/10 dark:border-white/10 px-3 py-2 text-sm overflow-x-auto"><code>claude mcp add --transport http sessy <%= mcp_endpoint_url %> \
   --header "Authorization: Bearer YOUR_API_KEY"</code></pre>
       </div>
 
@@ -31,7 +31,7 @@
         <pre class="mt-2 border border-zinc-950/10 dark:border-white/10 px-3 py-2 text-sm overflow-x-auto"><code>{
   "mcpServers": {
     "sessy": {
-      "url": "<%= @endpoint_url %>",
+      "url": "<%= mcp_endpoint_url %>",
       "headers": { "Authorization": "Bearer YOUR_API_KEY" }
     }
   }
@@ -42,7 +42,7 @@
         <h2 class="text-sm font-medium">Codex</h2>
         <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">Add to <code>~/.codex/config.toml</code> (with <code>SESSY_API_KEY</code> exported in your shell):</p>
         <pre class="mt-2 border border-zinc-950/10 dark:border-white/10 px-3 py-2 text-sm overflow-x-auto"><code>[mcp_servers.sessy]
-url = "<%= @endpoint_url %>"
+url = "<%= mcp_endpoint_url %>"
 bearer_token_env_var = "SESSY_API_KEY"</code></pre>
       </div>
 

--- a/test/controllers/api_keys_controller_test.rb
+++ b/test/controllers/api_keys_controller_test.rb
@@ -18,7 +18,7 @@ class ApiKeysControllerTest < ActionDispatch::IntegrationTest
     assert_no_match "sessy_instance_test_key", response.body
   end
 
-  test "create shows the token once and never again" do
+  test "create shows the token once with ready-to-paste connect snippets" do
     assert_difference "ApiKey.count", 1 do
       post api_keys_path, params: { api_key: { name: "Claude Code" } }
     end
@@ -27,9 +27,14 @@ class ApiKeysControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     token = ApiKey.order(:created_at).last
     assert_match(/sessy_\w+/, response.body)
+    assert_match "claude mcp add --transport http sessy", response.body
+    assert_match "~/.cursor/mcp.json", response.body
+    assert_match "~/.codex/config.toml", response.body
+    assert_operator response.body.scan(/Bearer sessy_\w{20,}/).size, :>=, 3, "each snippet embeds the key"
 
     get api_keys_path
     assert_no_match(/sessy_\w{20,}/, response.body)
+    assert_no_match(/claude mcp add/, response.body)
     assert_equal accounts(:instance), token.account
   end
 


### PR DESCRIPTION
## Summary

When an API key is created, the one-time token panel now shows three ready-to-paste connect blocks — the Claude Code command, Cursor `~/.cursor/mcp.json`, and Codex `~/.codex/config.toml` — each with the new key and the correct endpoint URL already embedded. Editor setup becomes: create key -> copy -> paste.

## Details

- Endpoint URL logic extracted into `ApplicationHelper#mcp_endpoint_url` (uses `API_HOST` when set, else the request host), shared by the docs page and the new panel.
- Codex snippet uses the inline `http_headers` form so it's genuinely one paste (no separate `export` step).
- Tests assert all three snippets render with the key embedded on create, and that neither the token nor the snippets appear on subsequent page loads. Verified visually against the real create flow.