### PR TITLE
Add MCP output schemas and server-card annotations

### DIFF
--- a/app/models/mcp_server.rb
+++ b/app/models/mcp_server.rb
@@ -4,7 +4,7 @@
 # untrusted third-party input flowing into agent context, and a read-only
 # surface caps what a prompt-injected agent can do to more reads.
 module McpServer
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 
   INSTRUCTIONS = <<~TEXT
     Sessy observes email sent through AWS SES: deliveries, bounces, complaints,
@@ -63,11 +63,18 @@ module McpServer
         schemes: [ "bearer" ]
       },
       tools: tools.map { |tool|
-        {
+        card = {
           name: tool.name_value,
           description: tool.description_value,
           inputSchema: tool.input_schema_value.to_h.except("$schema", :"$schema")
         }
+        if (output = tool.output_schema_value)
+          card[:outputSchema] = output.to_h.except("$schema", :"$schema")
+        end
+        if (annotations = tool.annotations_value)
+          card[:annotations] = annotations.to_h
+        end
+        card
       },
       resources: [],
       prompts: []

--- a/app/models/mcp_server/base_tool.rb
+++ b/app/models/mcp_server/base_tool.rb
@@ -4,6 +4,19 @@ class McpServer::BaseTool < MCP::Tool
   # error: raw exception text never reaches programmatic callers.
   class ToolError < StandardError; end
 
+  # Shared by search_events / email_stats so scanners see one shape for the
+  # date window the tool actually applied.
+  APPLIED_DATE_RANGE_SCHEMA = {
+    type: "object",
+    properties: {
+      preset: { type: "string" },
+      from: { type: [ "string", "null" ] },
+      to: { type: [ "string", "null" ] }
+    },
+    required: [ "preset", "from", "to" ],
+    additionalProperties: false
+  }.freeze
+
   class << self
     # Every tool on this server reads the account's own closed dataset, so
     # declare the full set of behavior hints once.

--- a/app/models/mcp_server/email_stats.rb
+++ b/app/models/mcp_server/email_stats.rb
@@ -15,6 +15,74 @@ class McpServer::EmailStats < McpServer::BaseTool
     required: [],
     additionalProperties: false
   )
+  output_schema(
+    properties: {
+      scope: {
+        type: "object",
+        properties: {
+          source_id: { type: [ "integer", "null" ] },
+          source_name: { type: "string" }
+        },
+        required: %w[source_id source_name],
+        additionalProperties: false
+      },
+      applied_date_range: APPLIED_DATE_RANGE_SCHEMA,
+      counts: {
+        type: "object",
+        properties: {
+          sent: { type: "integer" },
+          delivered: { type: "integer" },
+          bounced: { type: "integer" },
+          complaints: { type: "integer" },
+          opens: { type: "integer" },
+          clicks: { type: "integer" },
+          unique_opens: { type: "integer" },
+          unique_clicks: { type: "integer" }
+        },
+        required: %w[sent delivered bounced complaints opens clicks unique_opens unique_clicks],
+        additionalProperties: false
+      },
+      rates_percent: {
+        type: "object",
+        properties: {
+          bounce: { type: "number" },
+          complaint: { type: "number" },
+          open: { type: "number" },
+          click: { type: "number" }
+        },
+        required: %w[bounce complaint open click],
+        additionalProperties: false
+      },
+      bounce_breakdown: {
+        type: "object",
+        description: "Counts keyed by bounce subtype (Permanent, Transient, Undetermined, Unknown)",
+        additionalProperties: { type: "integer" }
+      },
+      daily_series: {
+        type: "object",
+        properties: {
+          dates: { type: "array", items: { type: "string" } },
+          series: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                key: { type: "string" },
+                values: { type: "array", items: { type: "integer" } }
+              },
+              required: %w[key values],
+              additionalProperties: false
+            }
+          }
+        },
+        required: %w[dates series],
+        additionalProperties: false
+      },
+      hint: { type: "string", description: "Present when there were no sends in the applied window" }
+    },
+    required: %w[scope applied_date_range counts rates_percent bounce_breakdown],
+    additionalProperties: false
+  )
 
   def self.perform(account:, source_id: nil, date_range: nil, from_date: nil, to_date: nil, include_daily_series: false, **)
     date_params = resolve_date_params(date_range: date_range, from_date: from_date, to_date: to_date)

--- a/app/models/mcp_server/get_message.rb
+++ b/app/models/mcp_server/get_message.rb
@@ -11,6 +11,50 @@ class McpServer::GetMessage < McpServer::BaseTool
     required: [ "ses_message_id" ],
     additionalProperties: false
   )
+  output_schema(
+    properties: {
+      message: {
+        type: "object",
+        properties: {
+          ses_message_id: { type: "string" },
+          subject: { type: [ "string", "null" ] },
+          from: { type: [ "string", "null" ] },
+          destinations: { type: "array", items: { type: "string" } },
+          tags: { type: "object", additionalProperties: true },
+          source: {
+            type: "object",
+            properties: {
+              id: { type: [ "integer", "null" ] },
+              name: { type: [ "string", "null" ] }
+            },
+            required: %w[id name],
+            additionalProperties: false
+          },
+          sent_at: { type: [ "string", "null" ] }
+        },
+        required: %w[ses_message_id subject from destinations tags source sent_at],
+        additionalProperties: false
+      },
+      events: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            event_type: { type: "string" },
+            bounce_type: { type: "string" },
+            recipient_email: { type: "string" },
+            event_at: { type: "string" },
+            details: { type: "object", description: "Event-type-specific SES diagnostics (truncated); omit raw_payload" }
+          },
+          required: %w[event_type recipient_email event_at],
+          additionalProperties: false
+        }
+      },
+      events_truncated: { type: "boolean", description: "True when more than #{EVENTS_LIMIT} events exist for this message" }
+    },
+    required: %w[message events],
+    additionalProperties: false
+  )
 
   def self.perform(account:, ses_message_id:, **)
     message = account_messages(account).find_by(ses_message_id: ses_message_id)

--- a/app/models/mcp_server/list_sources.rb
+++ b/app/models/mcp_server/list_sources.rb
@@ -3,6 +3,29 @@ class McpServer::ListSources < McpServer::BaseTool
   title "List sources"
   description "List this account's email sources with 30-day health stats (sent count, bounce rate, last event). Start here: the other tools take a source_id from these results."
   input_schema(properties: {}, required: [], additionalProperties: false)
+  output_schema(
+    properties: {
+      sources: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "integer" },
+            name: { type: "string" },
+            messages_count: { type: "integer" },
+            sent_30d: { type: "integer" },
+            bounce_rate_30d: { type: [ "number", "null" ], description: "Bounce rate percent over 30 days; null when nothing was sent" },
+            last_event_at: { type: [ "string", "null" ], description: "ISO 8601 timestamp of the newest event; null when the source has none" }
+          },
+          required: %w[id name messages_count sent_30d bounce_rate_30d last_event_at],
+          additionalProperties: false
+        }
+      },
+      guidance: { type: "string", description: "Present when the account has no sources yet" }
+    },
+    required: [ "sources" ],
+    additionalProperties: false
+  )
 
   def self.perform(account:, app_base_url:, **)
     sources = account.sources.alphabetically

--- a/app/models/mcp_server/search_events.rb
+++ b/app/models/mcp_server/search_events.rb
@@ -20,6 +20,32 @@ class McpServer::SearchEvents < McpServer::BaseTool
     required: [],
     additionalProperties: false
   )
+  output_schema(
+    properties: {
+      events: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            event_type: { type: "string" },
+            bounce_type: { type: "string" },
+            recipient_email: { type: "string" },
+            subject: { type: "string" },
+            ses_message_id: { type: "string" },
+            event_at: { type: "string" }
+          },
+          required: %w[event_type recipient_email ses_message_id event_at],
+          additionalProperties: false
+        }
+      },
+      has_more: { type: "boolean" },
+      next_cursor: { type: [ "string", "null" ] },
+      applied_date_range: APPLIED_DATE_RANGE_SCHEMA,
+      hint: { type: "string", description: "Present when the page is empty and a wider date window may help" }
+    },
+    required: %w[events has_more next_cursor applied_date_range],
+    additionalProperties: false
+  )
 
   def self.perform(account:, source_id: nil, query: nil, event_types: nil, bounce_types: nil,
     date_range: nil, from_date: nil, to_date: nil, limit: DEFAULT_LIMIT, cursor: nil, **)

--- a/test/controllers/mcp_controller_test.rb
+++ b/test/controllers/mcp_controller_test.rb
@@ -82,7 +82,7 @@ class McpControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil api_key.reload.last_used_at
   end
 
-  test "tools/list shows tools with titles and readOnlyHint" do
+  test "tools/list shows tools with titles, readOnlyHint, and output schemas" do
     rpc "tools/list"
 
     assert_response :success
@@ -95,6 +95,10 @@ class McpControllerTest < ActionDispatch::IntegrationTest
     assert_equal false, list_sources.dig("annotations", "destructiveHint")
     tools.each do |tool|
       assert_equal false, tool.dig("inputSchema", "additionalProperties"), "#{tool["name"]} schema must forbid unknown params"
+      assert tool["outputSchema"].present?, "#{tool["name"]} must declare an outputSchema"
+      assert tool.dig("outputSchema", "properties").present?, "#{tool["name"]} outputSchema needs named fields"
+      assert_equal true, tool.dig("annotations", "readOnlyHint"), "#{tool["name"]} must be read-only"
+      assert_equal false, tool.dig("annotations", "destructiveHint"), "#{tool["name"]} must not be destructive"
     end
   end
 

--- a/test/controllers/mcp_server_cards_controller_test.rb
+++ b/test/controllers/mcp_server_cards_controller_test.rb
@@ -14,6 +14,17 @@ class McpServerCardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal %w[list_sources search_events get_message email_stats],
       card["tools"].map { |tool| tool["name"] }
     assert_not_includes card.dig("authentication", "schemes"), "oauth2"
+
+    # Smithery and similar scanners can't auth through /mcp, so annotations and
+    # output schemas must be on the public card — not only on tools/list.
+    card["tools"].each do |tool|
+      assert_equal true, tool.dig("annotations", "readOnlyHint"), "#{tool["name"]} card annotations"
+      assert_equal false, tool.dig("annotations", "destructiveHint"), "#{tool["name"]} card annotations"
+      assert tool["outputSchema"].present?, "#{tool["name"]} card outputSchema"
+      assert tool.dig("outputSchema", "properties").present?, "#{tool["name"]} card outputSchema fields"
+      assert_nil tool.dig("outputSchema", "$schema")
+      assert_nil tool.dig("inputSchema", "$schema")
+    end
   end
 
   test "a configured API host serves the server card without redirecting" do


### PR DESCRIPTION
## Summary
- Declare named `output_schema` on all four MCP tools so clients get typed structured results (and the Ruby SDK validates them).
- Include `annotations` and `outputSchema` on `/.well-known/mcp/server-card.json` so Smithery/scanners that cannot auth through `/mcp` can score them.
- Bump `McpServer::VERSION` to `1.1.0`.

## Test plan
- [x] `bin/rails test test/controllers/mcp_controller_test.rb test/controllers/mcp_server_cards_controller_test.rb`
- [ ] After deploy, confirm server card includes annotations + outputSchema
- [ ] Re-check Smithery quality score (expect annotations + output schemas to pass; optional config intentionally still fails)