### PR TITLE
Add self-hosted update banner (days behind main)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -44,6 +44,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Resolve git revision metadata
+        id: gitmeta
+        shell: bash
+        run: |
+          set -eu
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "committed_at=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.2.0
 
@@ -90,6 +98,8 @@ jobs:
           build-args: |
             OCI_SOURCE=${{ env.SOURCE_URL }}
             OCI_DESCRIPTION=${{ env.IMAGE_DESCRIPTION }}
+            GIT_SHA=${{ steps.gitmeta.outputs.sha }}
+            GIT_COMMITTED_AT=${{ steps.gitmeta.outputs.committed_at }}
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,15 @@ USER 1000:1000
 COPY --chown=rails:rails --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --chown=rails:rails --from=build /rails /rails
 
+# Bake the source revision so self-hosted installs can detect when they are
+# behind upstream (see UpdateCheck). Empty when building locally without args.
+ARG GIT_SHA=
+ARG GIT_COMMITTED_AT=
+ENV SESSY_GIT_SHA=$GIT_SHA \
+    SESSY_GIT_COMMITTED_AT=$GIT_COMMITTED_AT
+RUN printf '%s' "$GIT_SHA" > /rails/REVISION && \
+    printf '%s' "$GIT_COMMITTED_AT" > /rails/COMMITTED_AT
+
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -497,7 +497,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.25.0) sha256=41059e7d0f9cb4023a33465d095f64b913fc9d1b808d6524c307da945fbcffcf
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -205,12 +205,12 @@ GEM
       stimulus-rails
       turbo-rails
     msgpack (1.8.4)
-    net-imap (0.6.4.1)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
@@ -369,13 +369,13 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
-    sqlite3 (2.9.5-aarch64-linux-gnu)
-    sqlite3 (2.9.5-aarch64-linux-musl)
-    sqlite3 (2.9.5-arm-linux-gnu)
-    sqlite3 (2.9.5-arm-linux-musl)
-    sqlite3 (2.9.5-arm64-darwin)
-    sqlite3 (2.9.5-x86_64-linux-gnu)
-    sqlite3 (2.9.5-x86_64-linux-musl)
+    sqlite3 (2.9.6-aarch64-linux-gnu)
+    sqlite3 (2.9.6-aarch64-linux-musl)
+    sqlite3 (2.9.6-arm-linux-gnu)
+    sqlite3 (2.9.6-arm-linux-musl)
+    sqlite3 (2.9.6-arm64-darwin)
+    sqlite3 (2.9.6-x86_64-linux-gnu)
+    sqlite3 (2.9.6-x86_64-linux-musl)
     sshkit (1.25.0)
       base64
       logger
@@ -530,7 +530,7 @@ CHECKSUMS
   local_time (3.0.3) sha256=c69a8974d993fdf6e60db02977ed23c070f203dcb3a1ff0de52ad3d2393f8303
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
-  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mcp (1.1.0) sha256=930dafc0a8f34941d210ad907dd70bf93c1763fa60b98cb9162c77263e5dac32
@@ -538,9 +538,9 @@ CHECKSUMS
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   mission_control-jobs (1.1.0) sha256=b13da9cde3344fec7c744b79d2a34c3ecd454f45d4d593d4c968ba762315e84c
   msgpack (1.8.4) sha256=4411c22d350dd1c20250f7eada3cca2695438c2f769cf0782f0cd065d90a3e7b
-  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
+  net-imap (0.6.6) sha256=96aa4ee50df3060203e649efc341f53480b791d49e150f2fdebf68beb141a8df
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
-  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
+  net-protocol (0.3.0) sha256=ba310c3d4f1cad46bb1ab20336b06669b1ff8f7c568d9cb9342b32a718547472
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d
   net-sftp (4.0.0) sha256=65bb91c859c2f93b09826757af11b69af931a3a9155050f50d1b06d384526364
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
@@ -599,13 +599,13 @@ CHECKSUMS
   solid_cable (4.0.2) sha256=084636a67679ad00d23088b33c84047e614bcf41ee559db24b414d83cdc42d03
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   solid_queue (1.6.0) sha256=b5fc3bb34162e09d8f960df6400d0f9304dc80fe66c2cfface31c32b228de6a1
-  sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
-  sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
-  sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b
-  sqlite3 (2.9.5-arm-linux-musl) sha256=bae1109d12b2e9f588455967729b008e1ff4feb7761749df695019c9079913c6
-  sqlite3 (2.9.5-arm64-darwin) sha256=d0cf444a70fc9395d513cfbcc1e6719e224aa645314e3824cb0474c721425aa2
-  sqlite3 (2.9.5-x86_64-linux-gnu) sha256=233dbcb6714148dd23bc5aeb33e8efd6eac974969564ddd5794c23d5f52b231e
-  sqlite3 (2.9.5-x86_64-linux-musl) sha256=e7d3a7474e8af0f96150c21abc203fbab5437206bfcdf11deab7741c0ca516f2
+  sqlite3 (2.9.6-aarch64-linux-gnu) sha256=d8b1f7d23efd7abac285775a9566562fc7debfef79d594e3a20354406fb7907c
+  sqlite3 (2.9.6-aarch64-linux-musl) sha256=3579e1c98cdc7ff5c3722847bb63ed4e1efb7ff675cb5e1e48ef2d4da5fb3bc9
+  sqlite3 (2.9.6-arm-linux-gnu) sha256=33541500e3615da02afe54a9cc38b17a6985d3cf9d8b76d6d0a83002f114e7ec
+  sqlite3 (2.9.6-arm-linux-musl) sha256=c5490af48bb228fefa54314e9541375c3907e70f8109f3881b5ff97e1c93ae33
+  sqlite3 (2.9.6-arm64-darwin) sha256=849b5d7f795e60fe25076d62c72dd722beb45b3850b516ad978d60ee848ec15b
+  sqlite3 (2.9.6-x86_64-linux-gnu) sha256=613188ce02f614126ddbc38c5e217ccffd6306d0dcd9adca9764547aa890a634
+  sqlite3 (2.9.6-x86_64-linux-musl) sha256=d493b11818a3573387a1d56e1ee8fa00da23a683a7a1cc063e7a0feeed843abf
   sshkit (1.25.0) sha256=c8c6543cdb60f91f1d277306d585dd11b6a064cb44eab0972827e4311ff96744
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   tailwindcss-rails (4.6.0) sha256=d99512867173d55c5ef8890427682299d8539f550cec1408b3d8667a538bd365

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -118,7 +118,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -518,7 +518,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.25.0) sha256=41059e7d0f9cb4023a33465d095f64b913fc9d1b808d6524c307da945fbcffcf
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -104,7 +104,7 @@ GEM
     aws-sdk-ses (1.102.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-sesv2 (1.105.0)
+    aws-sdk-sesv2 (1.106.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-sns (1.118.0)
@@ -196,7 +196,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -221,12 +221,12 @@ GEM
       stimulus-rails
       turbo-rails
     msgpack (1.8.4)
-    net-imap (0.6.4.1)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
@@ -385,13 +385,13 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
-    sqlite3 (2.9.5-aarch64-linux-gnu)
-    sqlite3 (2.9.5-aarch64-linux-musl)
-    sqlite3 (2.9.5-arm-linux-gnu)
-    sqlite3 (2.9.5-arm-linux-musl)
-    sqlite3 (2.9.5-arm64-darwin)
-    sqlite3 (2.9.5-x86_64-linux-gnu)
-    sqlite3 (2.9.5-x86_64-linux-musl)
+    sqlite3 (2.9.6-aarch64-linux-gnu)
+    sqlite3 (2.9.6-aarch64-linux-musl)
+    sqlite3 (2.9.6-arm-linux-gnu)
+    sqlite3 (2.9.6-arm-linux-musl)
+    sqlite3 (2.9.6-arm64-darwin)
+    sqlite3 (2.9.6-x86_64-linux-gnu)
+    sqlite3 (2.9.6-x86_64-linux-musl)
     sshkit (1.25.0)
       base64
       logger
@@ -510,7 +510,7 @@ CHECKSUMS
   aws-sdk-core (3.254.0) sha256=ee3e3220b8468a3c9e59daba18e6ec897bf5c7ce8adcc0670cfa2f1f092112fe
   aws-sdk-rails (5.1.0) sha256=8cffd3b60142e12a6747c91a7a609f668276b1082fc0c10810d5da3d14b13189
   aws-sdk-ses (1.102.0) sha256=02bca66d12b856c37fce614f0f2ed68198af1ae938f41e08c53afac3bda2618f
-  aws-sdk-sesv2 (1.105.0) sha256=d6c52b1ffb44686718f7fa62d87635932995a4774691f039931c75798098ab4f
+  aws-sdk-sesv2 (1.106.0) sha256=f0a3d18d1e6bf2a621defcaa215831176fb40c42810be44d7448d95b693ee766
   aws-sdk-sns (1.118.0) sha256=46786eb1a27f8031163572043ed750cd292a1ca408527c5589ba5ecd43a0d2b9
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -551,7 +551,7 @@ CHECKSUMS
   local_time (3.0.3) sha256=c69a8974d993fdf6e60db02977ed23c070f203dcb3a1ff0de52ad3d2393f8303
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
-  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mcp (1.1.0) sha256=930dafc0a8f34941d210ad907dd70bf93c1763fa60b98cb9162c77263e5dac32
@@ -559,9 +559,9 @@ CHECKSUMS
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   mission_control-jobs (1.1.0) sha256=b13da9cde3344fec7c744b79d2a34c3ecd454f45d4d593d4c968ba762315e84c
   msgpack (1.8.4) sha256=4411c22d350dd1c20250f7eada3cca2695438c2f769cf0782f0cd065d90a3e7b
-  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
+  net-imap (0.6.6) sha256=96aa4ee50df3060203e649efc341f53480b791d49e150f2fdebf68beb141a8df
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
-  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
+  net-protocol (0.3.0) sha256=ba310c3d4f1cad46bb1ab20336b06669b1ff8f7c568d9cb9342b32a718547472
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d
   net-sftp (4.0.0) sha256=65bb91c859c2f93b09826757af11b69af931a3a9155050f50d1b06d384526364
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
@@ -621,13 +621,13 @@ CHECKSUMS
   solid_cable (4.0.2) sha256=084636a67679ad00d23088b33c84047e614bcf41ee559db24b414d83cdc42d03
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   solid_queue (1.6.0) sha256=b5fc3bb34162e09d8f960df6400d0f9304dc80fe66c2cfface31c32b228de6a1
-  sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
-  sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
-  sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b
-  sqlite3 (2.9.5-arm-linux-musl) sha256=bae1109d12b2e9f588455967729b008e1ff4feb7761749df695019c9079913c6
-  sqlite3 (2.9.5-arm64-darwin) sha256=d0cf444a70fc9395d513cfbcc1e6719e224aa645314e3824cb0474c721425aa2
-  sqlite3 (2.9.5-x86_64-linux-gnu) sha256=233dbcb6714148dd23bc5aeb33e8efd6eac974969564ddd5794c23d5f52b231e
-  sqlite3 (2.9.5-x86_64-linux-musl) sha256=e7d3a7474e8af0f96150c21abc203fbab5437206bfcdf11deab7741c0ca516f2
+  sqlite3 (2.9.6-aarch64-linux-gnu) sha256=d8b1f7d23efd7abac285775a9566562fc7debfef79d594e3a20354406fb7907c
+  sqlite3 (2.9.6-aarch64-linux-musl) sha256=3579e1c98cdc7ff5c3722847bb63ed4e1efb7ff675cb5e1e48ef2d4da5fb3bc9
+  sqlite3 (2.9.6-arm-linux-gnu) sha256=33541500e3615da02afe54a9cc38b17a6985d3cf9d8b76d6d0a83002f114e7ec
+  sqlite3 (2.9.6-arm-linux-musl) sha256=c5490af48bb228fefa54314e9541375c3907e70f8109f3881b5ff97e1c93ae33
+  sqlite3 (2.9.6-arm64-darwin) sha256=849b5d7f795e60fe25076d62c72dd722beb45b3850b516ad978d60ee848ec15b
+  sqlite3 (2.9.6-x86_64-linux-gnu) sha256=613188ce02f614126ddbc38c5e217ccffd6306d0dcd9adca9764547aa890a634
+  sqlite3 (2.9.6-x86_64-linux-musl) sha256=d493b11818a3573387a1d56e1ee8fa00da23a683a7a1cc063e7a0feeed843abf
   sshkit (1.25.0) sha256=c8c6543cdb60f91f1d277306d585dd11b6a064cb44eab0972827e4311ff96744
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   tailwindcss-rails (4.6.0) sha256=d99512867173d55c5ef8890427682299d8539f550cec1408b3d8667a538bd365

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,12 @@ module ApplicationHelper
       ENV["HTTP_AUTH_PASSWORD"].blank? &&
       ENV["DISABLE_AUTH_WARNING"].blank?
   end
+
+  def update_check_status
+    @update_check_status ||= UpdateCheck.current
+  end
+
+  def show_update_banner?
+    update_check_status&.outdated?
+  end
 end

--- a/app/models/update_check.rb
+++ b/app/models/update_check.rb
@@ -2,17 +2,19 @@
 
 require "net/http"
 require "json"
+require "cgi"
 
 # Compares the baked-in git revision of a self-hosted install against the
 # latest commit on GitHub (public API, no token). Results are cached so page
 # loads do not hit GitHub every request. Opt out with DISABLE_UPDATE_CHECKS=true.
 class UpdateCheck
-  CACHE_KEY = "sessy/update_check"
   CACHE_TTL = 24.hours
   FAILURE_TTL = 1.hour
   REQUEST_TIMEOUT = 2
   DEFAULT_REPO = "marckohlbrugge/sessy"
   DEFAULT_REF = "main"
+  REPO_PATTERN = /\A[\w.-]+\/[\w.-]+\z/
+  REF_PATTERN = /\A[\w.\/-]+\z/
 
   Status = Data.define(:latest_sha, :latest_committed_at, :days_behind) do
     def outdated?
@@ -21,6 +23,10 @@ class UpdateCheck
 
     def compare_url
       "https://github.com/#{UpdateCheck.repo}/compare/#{Sessy.revision}...#{UpdateCheck.ref}"
+    end
+
+    def docker_image
+      UpdateCheck.docker_image
     end
   end
 
@@ -44,36 +50,64 @@ class UpdateCheck
     def current
       return unless enabled?
 
-      cached = Rails.cache.read(CACHE_KEY)
+      cached = Rails.cache.read(cache_key)
       return if cached == :unavailable
       return status_from_cache(cached) if cached.is_a?(Hash)
 
-      status = fetch_remote
-      Rails.cache.write(CACHE_KEY, status_to_cache(status), expires_in: CACHE_TTL)
-      status
-    rescue StandardError => e
-      Rails.logger.warn("[UpdateCheck] #{e.class}: #{e.message}")
-      Rails.cache.write(CACHE_KEY, :unavailable, expires_in: FAILURE_TTL)
-      nil
+      fetch_mutex.synchronize { fetch_and_cache }
     end
 
     def refresh!
-      Rails.cache.delete(CACHE_KEY)
+      Rails.cache.delete(cache_key)
       current
     end
 
     def repo
-      ENV.fetch("SESSY_GITHUB_REPO", DEFAULT_REPO)
+      value = ENV["SESSY_GITHUB_REPO"].presence || DEFAULT_REPO
+      return value if value.match?(REPO_PATTERN)
+
+      Rails.logger.warn("[UpdateCheck] Ignoring invalid SESSY_GITHUB_REPO=#{value.inspect}")
+      DEFAULT_REPO
     end
 
     def ref
-      ENV.fetch("SESSY_GITHUB_REF", DEFAULT_REF)
+      value = ENV["SESSY_GITHUB_REF"].presence || DEFAULT_REF
+      return value if value.match?(REF_PATTERN)
+
+      Rails.logger.warn("[UpdateCheck] Ignoring invalid SESSY_GITHUB_REF=#{value.inspect}")
+      DEFAULT_REF
+    end
+
+    def docker_image
+      "ghcr.io/#{repo.downcase}:#{ref}"
+    end
+
+    def cache_key
+      "sessy/update_check/#{Sessy.revision}/#{repo}/#{ref}"
     end
 
     private
 
+    def fetch_mutex
+      @fetch_mutex ||= Mutex.new
+    end
+
+    def fetch_and_cache
+      cached = Rails.cache.read(cache_key)
+      return if cached == :unavailable
+      return status_from_cache(cached) if cached.is_a?(Hash)
+
+      status = fetch_remote
+      Rails.cache.write(cache_key, status_to_cache(status), expires_in: CACHE_TTL)
+      status
+    rescue StandardError => e
+      Rails.logger.warn("[UpdateCheck] #{e.class}: #{e.message}")
+      Rails.cache.write(cache_key, :unavailable, expires_in: FAILURE_TTL)
+      nil
+    end
+
     def fetch_remote
-      uri = URI("https://api.github.com/repos/#{repo}/commits/#{ref}")
+      uri = URI("https://api.github.com/repos/#{repo}/commits/#{CGI.escape(ref)}")
       response = (fetcher || method(:get_json)).call(uri)
 
       latest_sha = response.fetch("sha")
@@ -82,7 +116,11 @@ class UpdateCheck
           response.dig("commit", "author", "date")
       )
 
-      days_behind = if latest_sha.start_with?(Sessy.revision) || Sessy.revision.start_with?(latest_sha)
+      build_status(latest_sha: latest_sha, latest_committed_at: latest_committed_at)
+    end
+
+    def build_status(latest_sha:, latest_committed_at:)
+      days_behind = if sha_matches?(latest_sha)
         0
       else
         (latest_committed_at.to_date - Sessy.committed_at.to_date).to_i
@@ -95,15 +133,23 @@ class UpdateCheck
       )
     end
 
+    def sha_matches?(latest_sha)
+      revision = Sessy.revision.to_s
+      revision.present? && (latest_sha.start_with?(revision) || revision.start_with?(latest_sha))
+    end
+
     def get_json(uri)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.open_timeout = REQUEST_TIMEOUT
       http.read_timeout = REQUEST_TIMEOUT
+      http.write_timeout = REQUEST_TIMEOUT if http.respond_to?(:write_timeout=)
+      http.ssl_timeout = REQUEST_TIMEOUT if http.respond_to?(:ssl_timeout=)
+      http.max_retries = 0 if http.respond_to?(:max_retries=)
 
       request = Net::HTTP::Get.new(uri)
       request["Accept"] = "application/vnd.github+json"
-      request["User-Agent"] = "Sessy-UpdateCheck"
+      request["User-Agent"] = "Sessy (+https://github.com/marckohlbrugge/sessy)"
 
       response = http.request(request)
       raise "GitHub API #{response.code}" unless response.is_a?(Net::HTTPSuccess)
@@ -114,17 +160,15 @@ class UpdateCheck
     def status_to_cache(status)
       {
         "latest_sha" => status.latest_sha,
-        "latest_committed_at" => status.latest_committed_at.iso8601,
-        "days_behind" => status.days_behind
+        "latest_committed_at" => status.latest_committed_at.iso8601
       }
     end
 
     def status_from_cache(cached)
       cached = cached.stringify_keys
-      Status.new(
+      build_status(
         latest_sha: cached.fetch("latest_sha"),
-        latest_committed_at: Time.iso8601(cached.fetch("latest_committed_at")),
-        days_behind: cached.fetch("days_behind").to_i
+        latest_committed_at: Time.iso8601(cached.fetch("latest_committed_at"))
       )
     end
   end

--- a/app/models/update_check.rb
+++ b/app/models/update_check.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+
+# Compares the baked-in git revision of a self-hosted install against the
+# latest commit on GitHub (public API, no token). Results are cached so page
+# loads do not hit GitHub every request. Opt out with DISABLE_UPDATE_CHECKS=true.
+class UpdateCheck
+  CACHE_KEY = "sessy/update_check"
+  CACHE_TTL = 24.hours
+  FAILURE_TTL = 1.hour
+  REQUEST_TIMEOUT = 2
+  DEFAULT_REPO = "marckohlbrugge/sessy"
+  DEFAULT_REF = "main"
+
+  Status = Data.define(:latest_sha, :latest_committed_at, :days_behind) do
+    def outdated?
+      days_behind.positive?
+    end
+
+    def compare_url
+      "https://github.com/#{UpdateCheck.repo}/compare/#{Sessy.revision}...#{UpdateCheck.ref}"
+    end
+  end
+
+  class << self
+    # Overridable in tests. Receives a URI, returns a parsed JSON Hash.
+    attr_accessor :fetcher
+
+    # When set (true/false), bypasses the normal enabled? heuristics. Used by tests.
+    attr_accessor :force_enabled
+
+    def enabled?
+      return force_enabled unless force_enabled.nil?
+      return false if Sessy.saas?
+      return false if Rails.env.local?
+      return false if ENV["DISABLE_UPDATE_CHECKS"].present?
+      return false if Sessy.revision.blank? || Sessy.committed_at.blank?
+
+      true
+    end
+
+    def current
+      return unless enabled?
+
+      cached = Rails.cache.read(CACHE_KEY)
+      return if cached == :unavailable
+      return status_from_cache(cached) if cached.is_a?(Hash)
+
+      status = fetch_remote
+      Rails.cache.write(CACHE_KEY, status_to_cache(status), expires_in: CACHE_TTL)
+      status
+    rescue StandardError => e
+      Rails.logger.warn("[UpdateCheck] #{e.class}: #{e.message}")
+      Rails.cache.write(CACHE_KEY, :unavailable, expires_in: FAILURE_TTL)
+      nil
+    end
+
+    def refresh!
+      Rails.cache.delete(CACHE_KEY)
+      current
+    end
+
+    def repo
+      ENV.fetch("SESSY_GITHUB_REPO", DEFAULT_REPO)
+    end
+
+    def ref
+      ENV.fetch("SESSY_GITHUB_REF", DEFAULT_REF)
+    end
+
+    private
+
+    def fetch_remote
+      uri = URI("https://api.github.com/repos/#{repo}/commits/#{ref}")
+      response = (fetcher || method(:get_json)).call(uri)
+
+      latest_sha = response.fetch("sha")
+      latest_committed_at = Time.iso8601(
+        response.dig("commit", "committer", "date") ||
+          response.dig("commit", "author", "date")
+      )
+
+      days_behind = if latest_sha.start_with?(Sessy.revision) || Sessy.revision.start_with?(latest_sha)
+        0
+      else
+        (latest_committed_at.to_date - Sessy.committed_at.to_date).to_i
+      end
+
+      Status.new(
+        latest_sha: latest_sha,
+        latest_committed_at: latest_committed_at,
+        days_behind: [ days_behind, 0 ].max
+      )
+    end
+
+    def get_json(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = REQUEST_TIMEOUT
+      http.read_timeout = REQUEST_TIMEOUT
+
+      request = Net::HTTP::Get.new(uri)
+      request["Accept"] = "application/vnd.github+json"
+      request["User-Agent"] = "Sessy-UpdateCheck"
+
+      response = http.request(request)
+      raise "GitHub API #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)
+    end
+
+    def status_to_cache(status)
+      {
+        "latest_sha" => status.latest_sha,
+        "latest_committed_at" => status.latest_committed_at.iso8601,
+        "days_behind" => status.days_behind
+      }
+    end
+
+    def status_from_cache(cached)
+      cached = cached.stringify_keys
+      Status.new(
+        latest_sha: cached.fetch("latest_sha"),
+        latest_committed_at: Time.iso8601(cached.fetch("latest_committed_at")),
+        days_behind: cached.fetch("days_behind").to_i
+      )
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,17 @@
         </div>
       <% end %>
 
+      <% if show_update_banner? %>
+        <% status = update_check_status %>
+        <div class="bg-sky-500/10 text-sky-800 dark:text-sky-300 px-4 py-2 text-center text-sm border-b border-sky-500/20">
+          <strong>Update available.</strong>
+          This install is <%= pluralize(status.days_behind, "day") %> behind.
+          Pull <code class="bg-sky-500/10 px-1">ghcr.io/marckohlbrugge/sessy:main</code>
+          or
+          <%= link_to "see what changed", status.compare_url, class: "underline underline-offset-2", target: "_blank", rel: "noopener" %>.
+        </div>
+      <% end %>
+
       <main>
         <%= yield %>
       </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
         <div class="bg-sky-500/10 text-sky-800 dark:text-sky-300 px-4 py-2 text-center text-sm border-b border-sky-500/20">
           <strong>Update available.</strong>
           This install is <%= pluralize(status.days_behind, "day") %> behind.
-          Pull <code class="bg-sky-500/10 px-1">ghcr.io/marckohlbrugge/sessy:main</code>
+          Pull <code class="bg-sky-500/10 px-1"><%= status.docker_image %></code>
           or
           <%= link_to "see what changed", status.compare_url, class: "underline underline-offset-2", target: "_blank", rel: "noopener" %>.
         </div>

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -80,6 +80,16 @@ If HTTP Basic Auth is not configured, Sessy will display a security warning bann
 docker run --environment DISABLE_AUTH_WARNING=true ...
 ```
 
+#### Update checks
+
+Self-hosted installs periodically check GitHub's public API for newer commits on `main` and show a banner when your image is at least one day behind. The check runs at most once per day (cached), only from authenticated dashboard page loads, and only phones GitHub — not Sessy's servers.
+
+Your image's git revision is baked in at build time. To turn the banner off:
+
+```sh
+docker run --environment DISABLE_UPDATE_CHECKS=true ...
+```
+
 #### Database
 
 By default, Sessy uses SQLite and stores its database in the mounted storage volume. This is the simplest setup and works great for most use cases.

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -82,9 +82,9 @@ docker run --environment DISABLE_AUTH_WARNING=true ...
 
 #### Update checks
 
-Self-hosted installs periodically check GitHub's public API for newer commits on `main` and show a banner when your image is at least one day behind. The check runs at most once per day (cached), only from authenticated dashboard page loads, and only phones GitHub — not Sessy's servers.
+Self-hosted installs periodically check GitHub's public API for newer commits on `main` and show a banner when your image is at least one day behind. The check runs at most once per day (cached) when someone loads the dashboard HTML, and only phones GitHub — not Sessy's servers. If the dashboard is open without HTTP Basic Auth, any visitor who can load a page may trigger the check.
 
-Your image's git revision is baked in at build time. To turn the banner off:
+Your image's git revision is baked in at build time. Cache entries are scoped to that revision, so pulling a newer image starts a fresh check. To turn the banner off:
 
 ```sh
 docker run --environment DISABLE_UPDATE_CHECKS=true ...

--- a/lib/sessy.rb
+++ b/lib/sessy.rb
@@ -15,6 +15,30 @@ module Sessy
       return @saas if defined?(@saas)
       @saas = defined?(Sessy::Saas) ? true : false
     end
+
+    # Git SHA baked into the Docker image (or SESSY_GIT_SHA / REVISION file).
+    # Blank for local/dev builds that were not built with revision metadata.
+    def revision
+      ENV["SESSY_GIT_SHA"].presence || read_build_file("REVISION").presence
+    end
+
+    # Commit timestamp for {#revision}, used to express how many days an
+    # install is behind the latest upstream commit.
+    def committed_at
+      raw = ENV["SESSY_GIT_COMMITTED_AT"].presence || read_build_file("COMMITTED_AT").presence
+      raw && Time.iso8601(raw)
+    rescue ArgumentError
+      nil
+    end
+
+    private
+
+    def read_build_file(name)
+      path = Rails.root.join(name)
+      File.read(path).strip if path.exist?
+    rescue Errno::ENOENT, Errno::EACCES
+      nil
+    end
   end
 
   class DbAdapter

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,6 +1,19 @@
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
+  setup do
+    @previous_force = UpdateCheck.force_enabled
+    @previous_fetcher = UpdateCheck.fetcher
+    @previous_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    UpdateCheck.force_enabled = @previous_force
+    UpdateCheck.fetcher = @previous_fetcher
+    Rails.cache = @previous_cache
+  end
+
   test "show_auth_warning? returns false in local environment" do
     assert_not show_auth_warning?
   end
@@ -14,6 +27,40 @@ class ApplicationHelperTest < ActionView::TestCase
   test "show_auth_warning? returns false when warning is disabled" do
     with_env("DISABLE_AUTH_WARNING" => "1") do
       assert_not show_auth_warning?
+    end
+  end
+
+  test "show_update_banner? returns false when update check is blank" do
+    UpdateCheck.force_enabled = false
+    assert_not show_update_banner?
+  end
+
+  test "show_update_banner? returns true when status is outdated" do
+    with_env("SESSY_GIT_SHA" => "abc1234", "SESSY_GIT_COMMITTED_AT" => "2026-08-01T12:00:00Z") do
+      UpdateCheck.force_enabled = true
+      UpdateCheck.fetcher = ->(_uri) {
+        {
+          "sha" => "def5678",
+          "commit" => { "committer" => { "date" => "2026-08-10T12:00:00Z" } }
+        }
+      }
+
+      assert show_update_banner?
+      assert_equal 9, update_check_status.days_behind
+    end
+  end
+
+  test "show_update_banner? returns false when status is current" do
+    with_env("SESSY_GIT_SHA" => "abc1234", "SESSY_GIT_COMMITTED_AT" => "2026-08-01T12:00:00Z") do
+      UpdateCheck.force_enabled = true
+      UpdateCheck.fetcher = ->(_uri) {
+        {
+          "sha" => "abc1234full",
+          "commit" => { "committer" => { "date" => "2026-08-01T12:00:00Z" } }
+        }
+      }
+
+      assert_not show_update_banner?
     end
   end
 

--- a/test/lib/sessy_build_metadata_test.rb
+++ b/test/lib/sessy_build_metadata_test.rb
@@ -1,14 +1,42 @@
 require "test_helper"
 
 class SessyBuildMetadataTest < ActiveSupport::TestCase
+  setup do
+    @revision_path = Rails.root.join("REVISION")
+    @committed_at_path = Rails.root.join("COMMITTED_AT")
+    @had_revision = @revision_path.exist?
+    @had_committed_at = @committed_at_path.exist?
+    @previous_revision = @had_revision ? File.read(@revision_path) : nil
+    @previous_committed_at = @had_committed_at ? File.read(@committed_at_path) : nil
+  end
+
+  teardown do
+    restore_build_file(@revision_path, @had_revision, @previous_revision)
+    restore_build_file(@committed_at_path, @had_committed_at, @previous_committed_at)
+  end
+
   test "revision reads SESSY_GIT_SHA" do
     with_env("SESSY_GIT_SHA" => "deadbeef") do
       assert_equal "deadbeef", Sessy.revision
     end
   end
 
+  test "revision falls back to REVISION file" do
+    with_env("SESSY_GIT_SHA" => nil) do
+      File.write(@revision_path, "fromfile\n")
+      assert_equal "fromfile", Sessy.revision
+    end
+  end
+
   test "committed_at parses SESSY_GIT_COMMITTED_AT" do
     with_env("SESSY_GIT_COMMITTED_AT" => "2026-08-01T12:00:00Z") do
+      assert_equal Time.iso8601("2026-08-01T12:00:00Z"), Sessy.committed_at
+    end
+  end
+
+  test "committed_at falls back to COMMITTED_AT file" do
+    with_env("SESSY_GIT_COMMITTED_AT" => nil) do
+      File.write(@committed_at_path, "2026-08-01T12:00:00Z")
       assert_equal Time.iso8601("2026-08-01T12:00:00Z"), Sessy.committed_at
     end
   end
@@ -19,13 +47,42 @@ class SessyBuildMetadataTest < ActiveSupport::TestCase
     end
   end
 
+  test "blank build files are treated as missing" do
+    with_env("SESSY_GIT_SHA" => nil, "SESSY_GIT_COMMITTED_AT" => nil) do
+      File.write(@revision_path, "   ")
+      File.write(@committed_at_path, "")
+      assert_nil Sessy.revision
+      assert_nil Sessy.committed_at
+    end
+  end
+
   private
+
+  def restore_build_file(path, had_file, contents)
+    if had_file
+      File.write(path, contents)
+    elsif path.exist?
+      File.delete(path)
+    end
+  end
 
   def with_env(vars)
     old_values = vars.keys.to_h { |k| [ k, ENV[k] ] }
-    vars.each { |k, v| ENV[k] = v }
+    vars.each do |k, v|
+      if v.nil?
+        ENV.delete(k)
+      else
+        ENV[k] = v
+      end
+    end
     yield
   ensure
-    old_values.each { |k, v| ENV[k] = v }
+    old_values.each do |k, v|
+      if v.nil?
+        ENV.delete(k)
+      else
+        ENV[k] = v
+      end
+    end
   end
 end

--- a/test/lib/sessy_build_metadata_test.rb
+++ b/test/lib/sessy_build_metadata_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class SessyBuildMetadataTest < ActiveSupport::TestCase
+  test "revision reads SESSY_GIT_SHA" do
+    with_env("SESSY_GIT_SHA" => "deadbeef") do
+      assert_equal "deadbeef", Sessy.revision
+    end
+  end
+
+  test "committed_at parses SESSY_GIT_COMMITTED_AT" do
+    with_env("SESSY_GIT_COMMITTED_AT" => "2026-08-01T12:00:00Z") do
+      assert_equal Time.iso8601("2026-08-01T12:00:00Z"), Sessy.committed_at
+    end
+  end
+
+  test "committed_at returns nil for invalid timestamps" do
+    with_env("SESSY_GIT_COMMITTED_AT" => "not-a-time") do
+      assert_nil Sessy.committed_at
+    end
+  end
+
+  private
+
+  def with_env(vars)
+    old_values = vars.keys.to_h { |k| [ k, ENV[k] ] }
+    vars.each { |k, v| ENV[k] = v }
+    yield
+  ensure
+    old_values.each { |k, v| ENV[k] = v }
+  end
+end

--- a/test/lib/sessy_build_metadata_test.rb
+++ b/test/lib/sessy_build_metadata_test.rb
@@ -1,42 +1,14 @@
 require "test_helper"
 
 class SessyBuildMetadataTest < ActiveSupport::TestCase
-  setup do
-    @revision_path = Rails.root.join("REVISION")
-    @committed_at_path = Rails.root.join("COMMITTED_AT")
-    @had_revision = @revision_path.exist?
-    @had_committed_at = @committed_at_path.exist?
-    @previous_revision = @had_revision ? File.read(@revision_path) : nil
-    @previous_committed_at = @had_committed_at ? File.read(@committed_at_path) : nil
-  end
-
-  teardown do
-    restore_build_file(@revision_path, @had_revision, @previous_revision)
-    restore_build_file(@committed_at_path, @had_committed_at, @previous_committed_at)
-  end
-
   test "revision reads SESSY_GIT_SHA" do
     with_env("SESSY_GIT_SHA" => "deadbeef") do
       assert_equal "deadbeef", Sessy.revision
     end
   end
 
-  test "revision falls back to REVISION file" do
-    with_env("SESSY_GIT_SHA" => nil) do
-      File.write(@revision_path, "fromfile\n")
-      assert_equal "fromfile", Sessy.revision
-    end
-  end
-
   test "committed_at parses SESSY_GIT_COMMITTED_AT" do
     with_env("SESSY_GIT_COMMITTED_AT" => "2026-08-01T12:00:00Z") do
-      assert_equal Time.iso8601("2026-08-01T12:00:00Z"), Sessy.committed_at
-    end
-  end
-
-  test "committed_at falls back to COMMITTED_AT file" do
-    with_env("SESSY_GIT_COMMITTED_AT" => nil) do
-      File.write(@committed_at_path, "2026-08-01T12:00:00Z")
       assert_equal Time.iso8601("2026-08-01T12:00:00Z"), Sessy.committed_at
     end
   end
@@ -47,23 +19,79 @@ class SessyBuildMetadataTest < ActiveSupport::TestCase
     end
   end
 
+  test "revision falls back to REVISION file" do
+    with_build_files_locked do
+      with_env("SESSY_GIT_SHA" => nil) do
+        write_build_file("REVISION", "fromfile\n")
+        assert_equal "fromfile", Sessy.revision
+      end
+    end
+  end
+
+  test "committed_at falls back to COMMITTED_AT file" do
+    with_build_files_locked do
+      with_env("SESSY_GIT_COMMITTED_AT" => nil) do
+        write_build_file("COMMITTED_AT", "2026-08-01T12:00:00Z")
+        assert_equal Time.iso8601("2026-08-01T12:00:00Z"), Sessy.committed_at
+      end
+    end
+  end
+
   test "blank build files are treated as missing" do
-    with_env("SESSY_GIT_SHA" => nil, "SESSY_GIT_COMMITTED_AT" => nil) do
-      File.write(@revision_path, "   ")
-      File.write(@committed_at_path, "")
-      assert_nil Sessy.revision
-      assert_nil Sessy.committed_at
+    with_build_files_locked do
+      with_env("SESSY_GIT_SHA" => nil, "SESSY_GIT_COMMITTED_AT" => nil) do
+        write_build_file("REVISION", "   ")
+        write_build_file("COMMITTED_AT", "")
+        assert_nil Sessy.revision
+        assert_nil Sessy.committed_at
+      end
     end
   end
 
   private
 
-  def restore_build_file(path, had_file, contents)
-    if had_file
-      File.write(path, contents)
-    elsif path.exist?
-      File.delete(path)
+  def with_build_files_locked
+    FileUtils.mkdir_p(Rails.root.join("tmp"))
+    lock_path = Rails.root.join("tmp/sessy_build_metadata_test.lock")
+    File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |lock|
+      lock.flock(File::LOCK_EX)
+      previous = snapshot_build_files
+      begin
+        yield
+      ensure
+        restore_build_files(previous)
+        lock.flock(File::LOCK_UN)
+      end
     end
+  end
+
+  def snapshot_build_files
+    {
+      "REVISION" => read_build_file_if_present("REVISION"),
+      "COMMITTED_AT" => read_build_file_if_present("COMMITTED_AT")
+    }
+  end
+
+  def restore_build_files(previous)
+    previous.each do |name, contents|
+      path = Rails.root.join(name)
+      if contents.nil?
+        File.delete(path) if path.exist?
+      else
+        File.write(path, contents)
+      end
+    end
+  end
+
+  def read_build_file_if_present(name)
+    path = Rails.root.join(name)
+    File.read(path) if path.exist?
+  rescue Errno::ENOENT
+    nil
+  end
+
+  def write_build_file(name, contents)
+    File.write(Rails.root.join(name), contents)
   end
 
   def with_env(vars)

--- a/test/models/update_check_test.rb
+++ b/test/models/update_check_test.rb
@@ -54,6 +54,7 @@ class UpdateCheckTest < ActiveSupport::TestCase
       assert_equal 9, status.days_behind
       assert_equal "def5678", status.latest_sha
       assert_includes status.compare_url, "#{Sessy.revision}...main"
+      assert_equal "ghcr.io/marckohlbrugge/sessy:main", status.docker_image
     end
   end
 
@@ -79,6 +80,23 @@ class UpdateCheckTest < ActiveSupport::TestCase
     end
   end
 
+  test "current uses author date when committer date is missing" do
+    with_build_metadata do
+      UpdateCheck.fetcher = ->(_uri) {
+        {
+          "sha" => "def5678",
+          "commit" => {
+            "author" => { "date" => "2026-08-10T12:00:00Z" }
+          }
+        }
+      }
+
+      status = UpdateCheck.current
+
+      assert_equal 9, status.days_behind
+    end
+  end
+
   test "current caches successful responses" do
     with_build_metadata do
       calls = 0
@@ -94,12 +112,56 @@ class UpdateCheckTest < ActiveSupport::TestCase
     end
   end
 
-  test "current returns nil and caches failure briefly on API errors" do
+  test "current returns nil and skips fetcher while failure is cached" do
     with_build_metadata do
-      UpdateCheck.fetcher = ->(_uri) { raise Timeout::Error, "timed out" }
+      calls = 0
+      UpdateCheck.fetcher = ->(_uri) {
+        calls += 1
+        raise Timeout::Error, "timed out"
+      }
 
       assert_nil UpdateCheck.current
-      assert_equal :unavailable, Rails.cache.read(UpdateCheck::CACHE_KEY)
+      assert_equal :unavailable, Rails.cache.read(UpdateCheck.cache_key)
+
+      assert_nil UpdateCheck.current
+      assert_equal 1, calls
+    end
+  end
+
+  test "cache is scoped to the running revision after an image upgrade" do
+    with_build_metadata("SESSY_GIT_SHA" => "oldrev") do
+      stub_github_commit(sha: "newrev", date: "2026-08-10T12:00:00Z")
+      stale = UpdateCheck.current
+      assert stale.outdated?
+    end
+
+    with_build_metadata("SESSY_GIT_SHA" => "newrev", "SESSY_GIT_COMMITTED_AT" => "2026-08-10T12:00:00Z") do
+      calls = 0
+      UpdateCheck.fetcher = ->(_uri) {
+        calls += 1
+        github_payload(sha: "newrev", date: "2026-08-10T12:00:00Z")
+      }
+
+      status = UpdateCheck.current
+
+      assert_not status.outdated?
+      assert_equal 1, calls
+      assert_equal 0, status.days_behind
+    end
+  end
+
+  test "status_from_cache recomputes days_behind for the current revision" do
+    with_build_metadata("SESSY_GIT_SHA" => "abc1234", "SESSY_GIT_COMMITTED_AT" => "2026-08-01T12:00:00Z") do
+      Rails.cache.write(
+        UpdateCheck.cache_key,
+        { "latest_sha" => "abc1234full", "latest_committed_at" => "2026-08-20T12:00:00Z" },
+        expires_in: UpdateCheck::CACHE_TTL
+      )
+
+      status = UpdateCheck.current
+
+      assert_not status.outdated?
+      assert_equal 0, status.days_behind
     end
   end
 
@@ -128,13 +190,28 @@ class UpdateCheckTest < ActiveSupport::TestCase
     assert_equal 0, calls
   end
 
+  test "repo and ref fall back to defaults when env values are invalid" do
+    with_env("SESSY_GITHUB_REPO" => "not a repo", "SESSY_GITHUB_REF" => "bad ref?") do
+      assert_equal UpdateCheck::DEFAULT_REPO, UpdateCheck.repo
+      assert_equal UpdateCheck::DEFAULT_REF, UpdateCheck.ref
+    end
+  end
+
+  test "docker_image follows configured repo and ref" do
+    with_env("SESSY_GITHUB_REPO" => "acme/sessy-fork", "SESSY_GITHUB_REF" => "stable") do
+      assert_equal "ghcr.io/acme/sessy-fork:stable", UpdateCheck.docker_image
+    end
+  end
+
   private
 
   def with_build_metadata(extra = {})
     defaults = {
       "SESSY_GIT_SHA" => "abc1234",
       "SESSY_GIT_COMMITTED_AT" => "2026-08-01T12:00:00Z",
-      "DISABLE_UPDATE_CHECKS" => nil
+      "DISABLE_UPDATE_CHECKS" => nil,
+      "SESSY_GITHUB_REPO" => nil,
+      "SESSY_GITHUB_REF" => nil
     }
     with_env(defaults.merge(extra)) { yield }
   end

--- a/test/models/update_check_test.rb
+++ b/test/models/update_check_test.rb
@@ -1,0 +1,174 @@
+require "test_helper"
+
+class UpdateCheckTest < ActiveSupport::TestCase
+  setup do
+    @previous_cache = Rails.cache
+    @previous_fetcher = UpdateCheck.fetcher
+    @previous_force = UpdateCheck.force_enabled
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    UpdateCheck.force_enabled = true
+  end
+
+  teardown do
+    Rails.cache = @previous_cache
+    UpdateCheck.fetcher = @previous_fetcher
+    UpdateCheck.force_enabled = @previous_force
+  end
+
+  test "enabled? is false in local environments by default" do
+    UpdateCheck.force_enabled = nil
+    with_build_metadata do
+      assert_not UpdateCheck.enabled?
+    end
+  end
+
+  test "enabled? is false when update checks are disabled" do
+    UpdateCheck.force_enabled = nil
+    with_build_metadata("DISABLE_UPDATE_CHECKS" => "true") do
+      assert_not UpdateCheck.enabled?
+    end
+  end
+
+  test "enabled? is false without baked revision metadata" do
+    UpdateCheck.force_enabled = nil
+    with_env("SESSY_GIT_SHA" => nil, "SESSY_GIT_COMMITTED_AT" => nil, "DISABLE_UPDATE_CHECKS" => nil) do
+      assert_not UpdateCheck.enabled?
+    end
+  end
+
+  test "enabled? respects force_enabled override" do
+    UpdateCheck.force_enabled = true
+    assert UpdateCheck.enabled?
+
+    UpdateCheck.force_enabled = false
+    assert_not UpdateCheck.enabled?
+  end
+
+  test "current reports days behind when upstream is newer" do
+    with_build_metadata do
+      stub_github_commit(sha: "def5678", date: "2026-08-10T12:00:00Z")
+
+      status = UpdateCheck.current
+
+      assert status.outdated?
+      assert_equal 9, status.days_behind
+      assert_equal "def5678", status.latest_sha
+      assert_includes status.compare_url, "#{Sessy.revision}...main"
+    end
+  end
+
+  test "current is not outdated when SHAs match" do
+    with_build_metadata("SESSY_GIT_SHA" => "abc1234") do
+      stub_github_commit(sha: "abc1234fullsha", date: "2026-08-20T12:00:00Z")
+
+      status = UpdateCheck.current
+
+      assert_not status.outdated?
+      assert_equal 0, status.days_behind
+    end
+  end
+
+  test "current is not outdated when upstream commit is older" do
+    with_build_metadata do
+      stub_github_commit(sha: "old9999", date: "2026-07-01T12:00:00Z")
+
+      status = UpdateCheck.current
+
+      assert_not status.outdated?
+      assert_equal 0, status.days_behind
+    end
+  end
+
+  test "current caches successful responses" do
+    with_build_metadata do
+      calls = 0
+      UpdateCheck.fetcher = ->(_uri) {
+        calls += 1
+        github_payload(sha: "def5678", date: "2026-08-10T12:00:00Z")
+      }
+
+      UpdateCheck.current
+      UpdateCheck.current
+
+      assert_equal 1, calls
+    end
+  end
+
+  test "current returns nil and caches failure briefly on API errors" do
+    with_build_metadata do
+      UpdateCheck.fetcher = ->(_uri) { raise Timeout::Error, "timed out" }
+
+      assert_nil UpdateCheck.current
+      assert_equal :unavailable, Rails.cache.read(UpdateCheck::CACHE_KEY)
+    end
+  end
+
+  test "refresh! clears the cache and fetches again" do
+    with_build_metadata do
+      stub_github_commit(sha: "def5678", date: "2026-08-10T12:00:00Z")
+      UpdateCheck.current
+
+      stub_github_commit(sha: "fff0000", date: "2026-08-15T12:00:00Z")
+      status = UpdateCheck.refresh!
+
+      assert_equal "fff0000", status.latest_sha
+      assert_equal 14, status.days_behind
+    end
+  end
+
+  test "current is skipped when disabled" do
+    UpdateCheck.force_enabled = false
+    calls = 0
+    UpdateCheck.fetcher = ->(_uri) {
+      calls += 1
+      github_payload(sha: "def5678", date: "2026-08-10T12:00:00Z")
+    }
+
+    assert_nil UpdateCheck.current
+    assert_equal 0, calls
+  end
+
+  private
+
+  def with_build_metadata(extra = {})
+    defaults = {
+      "SESSY_GIT_SHA" => "abc1234",
+      "SESSY_GIT_COMMITTED_AT" => "2026-08-01T12:00:00Z",
+      "DISABLE_UPDATE_CHECKS" => nil
+    }
+    with_env(defaults.merge(extra)) { yield }
+  end
+
+  def stub_github_commit(sha:, date:)
+    UpdateCheck.fetcher = ->(_uri) { github_payload(sha: sha, date: date) }
+  end
+
+  def github_payload(sha:, date:)
+    {
+      "sha" => sha,
+      "commit" => {
+        "committer" => { "date" => date }
+      }
+    }
+  end
+
+  def with_env(vars)
+    old_values = vars.keys.to_h { |k| [ k, ENV[k] ] }
+    vars.each do |k, v|
+      if v.nil?
+        ENV.delete(k)
+      else
+        ENV[k] = v
+      end
+    end
+    yield
+  ensure
+    old_values.each do |k, v|
+      if v.nil?
+        ENV.delete(k)
+      else
+        ENV[k] = v
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Self-hosted Docker installs can now tell when they are behind upstream—without introducing semver releases or changelogs.

- Bake `GIT_SHA` / `GIT_COMMITTED_AT` into images at publish time
- On dashboard page loads, compare against GitHub’s public commits API (no token; not Sessy’s servers)
- Cache the result for 24 hours (failures for 1 hour), keyed by revision/repo/ref so upgrades don’t keep a stale banner
- Show a banner when the install is **at least one day** behind `main`, with a compare link and a pull hint derived from config
- Opt out with `DISABLE_UPDATE_CHECKS=true` (on by default for self-hosted production)
- Skipped for SaaS and local/dev environments, and when revision metadata is missing

### Review follow-ups

- Recompute `days_behind` from live revision metadata (don’t trust cached day counts)
- Mutex single-flight on cache miss; stricter Net::HTTP timeouts / no retries
- Allowlist `SESSY_GITHUB_REPO` / `SESSY_GITHUB_REF`
- Docs clarify checks run on any dashboard HTML load (auth is optional)

No in-place auto-update of the container (still needs an external pull/recreate). No version numbers or release tags required.

## Test plan

- [x] `bin/rails test` (133 tests)
- [x] Rubocop on touched Ruby files
- [x] Brakeman clean
- [ ] After merge + next image publish, confirm a deliberately old image shows the banner
- [ ] Confirm pulling a newer image clears the banner without waiting 24h
- [ ] Confirm `DISABLE_UPDATE_CHECKS=true` hides it

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a042da-1762-729c-9afa-41ca1f3a5a0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a042da-1762-729c-9afa-41ca1f3a5a0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

